### PR TITLE
Update name of fringestuff rule

### DIFF
--- a/src/Standards/AcquiaPHP/ruleset.xml
+++ b/src/Standards/AcquiaPHP/ruleset.xml
@@ -99,7 +99,7 @@
   <rule ref="Security.BadFunctions.Backticks"/>
   <rule ref="Security.BadFunctions.CallbackFunctions">
     <exclude
-      name="PHPCS_SecurityAudit.BadFunctions.CallbackFunctions.WarnFringestuff"/>
+      name="PHPCS_SecurityAudit.BadFunctions.CallbackFunctions.WarnCallbackFunctions"/>
   </rule>
   <rule ref="Security.BadFunctions.CryptoFunctions"/>
   <rule ref="Security.BadFunctions.EasyRFI"/>


### PR DESCRIPTION
A new version of phpcs-security-audit was just released that changes the name of this rule:
https://github.com/abderrahmaneib/phpcs-security-audit/pull/1/files

Thus, all of BLT's tests using this new version phpcs-security-audit are now failing.

Since this is tied to a specific version of phpcs-security-audit should we update the composer dependency as well?