### PR TITLE
Fixes #4: Explicitly set file extensions to scan

### DIFF
--- a/example/phpcs.xml.dist
+++ b/example/phpcs.xml.dist
@@ -14,7 +14,7 @@
   <arg name="parallel" value="10"/>
 
   <file>.</file>
-  
+
   <exclude-pattern>vendor/*</exclude-pattern>
 
   <rule ref="AcquiaDrupalStrict"/>

--- a/example/phpcs.xml.dist
+++ b/example/phpcs.xml.dist
@@ -5,12 +5,16 @@
 
   <description>An example PHP CodeSniffer configuration.</description>
 
+  <!-- Set extensions to scan (taken from Coder 8.3.6). -->
+  <!-- @see https://git.drupalcode.org/project/coder/blob/8.3.6/coder_sniffer/Drupal/ruleset.xml#L8 -->
+  <arg name="extensions" value="php,module,inc,install,test,profile,theme,css,info,txt,md,yml"/>
+
   <arg name="colors"/>
   <arg name="cache" value=".phpcs-cache"/>
   <arg name="parallel" value="10"/>
 
   <file>.</file>
-
+  
   <exclude-pattern>vendor/*</exclude-pattern>
 
   <rule ref="AcquiaDrupalStrict"/>


### PR DESCRIPTION
Fixes #4 

@TravisCarden this is the best solution I can think of to #4. Unfortunately it requires any downstream projects to manually update their phpcs.xml files (BLT added an update hook for this: https://github.com/acquia/blt/pull/3962). But I can't think of a better solution for this package.