### PR TITLE
Exclude the Security.BadFunctions.Asserts sniff.

### DIFF
--- a/src/Standards/AcquiaDrupalStrict/ruleset.xml
+++ b/src/Standards/AcquiaDrupalStrict/ruleset.xml
@@ -33,7 +33,10 @@
   <rule ref="DrupalPractice"/>
 
   <!-- PHPCS_SecurityAudit sniffs -->
-  <rule ref="Security.Drupal8"/>
+  <rule ref="Security.Drupal8">
+    <!-- Security.BadFunctions.Asserts forces assertions to use string expressions. String expressions have been deprecated since PHP 7.2.0 -->
+    <exclude name="Security.BadFunctions.Asserts"/>
+  </rule>
 
   <!-- Acquia PHP sniffs -->
   <rule ref="AcquiaPHP"/>

--- a/src/Standards/AcquiaDrupalTransitional/ruleset.xml
+++ b/src/Standards/AcquiaDrupalTransitional/ruleset.xml
@@ -33,7 +33,10 @@
   <rule ref="DrupalPractice.Commenting.ExpectedException"/>
 
   <!-- PHPCS_SecurityAudit sniffs -->
-  <rule ref="Security.Drupal8"/>
+  <rule ref="Security.Drupal8">
+    <!-- Security.BadFunctions.Asserts forces assertions to use string expressions. String expressions have been deprecated since PHP 7.2.0 -->
+    <exclude name="Security.BadFunctions.Asserts"/>
+  </rule>
 
   <!-- Acquia PHP sniffs -->
   <rule ref="AcquiaPHP"/>


### PR DESCRIPTION
`Security.BadFunctions.Asserts` sniff forces `assert()` function calls to use a string as their first
parameter.

Using strings as the first argument to assert() has been deprecated since PHP 7.2.0. Additionally, Drupal 8 no longer supports PHP 5, which required the first argument to assert() to be a string. Finally, versions of PHP 7 in which strings were not yet deprecated are no longer supported.

See: https://www.php.net/manual/en/function.assert.php#refsect1-function.assert-changelog
See: https://www.php.net/supported-versions.php