### PR TITLE
Don't scan for PHP in Markdown or Txt.

### DIFF
--- a/src/Standards/AcquiaPHP/ruleset.xml
+++ b/src/Standards/AcquiaPHP/ruleset.xml
@@ -31,8 +31,8 @@
 
   <!-- Internal sniffs -->
   <rule ref="Internal.NoCodeFound">
-    <!-- No PHP code in *.yml -->
-    <exclude-pattern>*.yml</exclude-pattern>
+    <!-- No PHP code in *.md or *.yml -->
+    <exclude-pattern>*.(md|yml)</exclude-pattern>
   </rule>
 
   <!-- MySource sniffs -->

--- a/src/Standards/AcquiaPHP/ruleset.xml
+++ b/src/Standards/AcquiaPHP/ruleset.xml
@@ -31,8 +31,8 @@
 
   <!-- Internal sniffs -->
   <rule ref="Internal.NoCodeFound">
-    <!-- No PHP code in *.md or *.yml -->
-    <exclude-pattern>*.(md|yml)</exclude-pattern>
+    <!-- No PHP code in *.md, *.txt, or *.yml -->
+    <exclude-pattern>*.(md|txt|yml)</exclude-pattern>
   </rule>
 
   <!-- MySource sniffs -->


### PR DESCRIPTION
If you have a markdown or txt file in your project, PHPCS will throw a warning:
> No PHP code was found in this file and short open tags are not allowed by this install of PHP. This file may be using short open tags but PHP does not allow them.

Seems like we should exclude markdown and txt like we do yaml. Although... I wonder why we are scanning them in the first place? Do the upstream sniffs actually check it for anything?