### PR TITLE
Improve PhpStorm inspection setup instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Rules are split into rulesets according to the project language and framework:
 
 1. Optionally add code checking to your [Git pre-commit hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) to prevent committing code with violations. Since client-side Git hooks are not copied when a repository is cloned, you might like to use an automated solution like [`BrainMaestro/composer-git-hooks`](https://packagist.org/packages/BrainMaestro/composer-git-hooks) to manage them, for example: [`example/composer.json`](example/composer.json).
 
-1. Optionally [configure PHP Code Sniffer integration in PhpStorm](https://www.jetbrains.com/help/phpstorm/using-php-code-sniffer.html) or your IDE or code editor of choice. You can import [`example/PhpStormInspections.xml`](example/PhpStormInspections.xml) to set up this integration automatically. You may need to modify the “custom” ruleset configuration to use your phpcs.xml or phpcs.xml.dist.
+1. Optionally [configure PHP Code Sniffer integration in PhpStorm](https://www.jetbrains.com/help/phpstorm/using-php-code-sniffer.html) or your IDE or code editor of choice. You can import [`example/PhpStormInspections.xml`](example/PhpStormInspections.xml) to set up default integration for new projects. When you open or create a new project for the first time, PhpStorm should automatically detect and set up PHPCS inspections based on these defaults. You will just need to uncheck the “installed standards paths” in the inspection settings for your project so that PhpStorm can find the Acquia Coding Standards.
 
 ## Contribution
 

--- a/example/PhpStormInspections.xml
+++ b/example/PhpStormInspections.xml
@@ -1,21 +1,14 @@
 <!--
-Import this file on PhpStorm's inspection settings screen to set up PHP CodeSniffer integration.
+Import this file on PhpStorm's inspection settings screen to set up default PHP CodeSniffer integration settings for new projects. Select "yes" when prompted to overwrite your default settings. Only the following settings will be modified:
 
-You may need to modify the "custom" ruleset path to use your phpcs.xml or phpcs.xml.dist if PhpStorm does not recognize the PROJECT_DIR variable.
+1. PHP_CodeSniffer severity will be raised to "Warning".
+2. File extensions to scan will be set to Acquia Coding Standard defaults.
+3. The built-in PHPDoc signature inspection will be set to ignore missing parameters, to match Acquia Coding Standard rules.
 
-You may wish to copy this to your own project in order to distribute any custom settings, such as if you use phpcs.xml instead of phpcs.xml.dist.
-
-To replicate this setup manually:
-1. Enable the PHP CodeSniffer inspection.
-2. Select your phpcs.xml.dist as the custom ruleset.
-3. Set the extensions to scan: php,module,inc,install,test,profile,theme,css,info,txt,md,yml
-4. Raise the severity to at least _Warning_.
 -->
 <profile version="1.0">
-  <option name="myName" value="Acquia Coding Standards" />
-  <inspection_tool class="PhpCSValidationInspection" enabled="true" level="WARNING" enabled_by_default="true">
-    <option name="CODING_STANDARD" value="Custom" />
-    <option name="CUSTOM_RULESET_PATH" value="$PROJECT_DIR$/phpcs.xml.dist" />
+  <option name="myName" value="Default" />
+  <inspection_tool class="PhpCSValidationInspection" enabled="false" level="WARNING" enabled_by_default="false">
     <option name="EXTENSIONS" value="php,module,inc,install,test,profile,theme,css,info,txt,md,yml" />
   </inspection_tool>
   <inspection_tool class="PhpDocSignatureInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">


### PR DESCRIPTION
At some point recently, it seems like [PhpStorm's PHP_CodeSniffer autoconfiguration abilities](https://www.jetbrains.com/help/phpstorm/using-php-code-sniffer.html) improved.

Specifically, you no longer have to manually specify the absolute path to a custom ruleset (phpcs.xml) or phpcs bin (vendor/bin/phpcs). PhpStorm will auto-discover and configure these if they are present in a project.

That means the setup instructions can be simplified, and our example profile made more portable.

With the new system, customers should import our custom inspection profile just once per machine when setting up PhpStorm, in order to configure the default inspection settings for new projects. After setting up a new project, everything will be configured automatically. The only manual intervention necessary is to uncheck the "installed standard paths" for the project. This seems to be a PhpStorm bug, there's no way I can tell to keep this unchecked by default for new projects, PhpStorm sees the Drupal Coder standards and wants to use them by default to the exclusion of everything else.

One big problem with the old system is that this custom inspection profile was stored at the IDE / machine level, rather than for individual projects. But the binary and standard paths had to be absolute, which meant that changing them in one project would break all other projects. This is fixed by simply taking that configuration out of the project defaults and letting PhpStorm's auto-discovery do its magic.