### PR TITLE
Retire PHP 7.1 compatibility

### DIFF
--- a/src/Standards/AcquiaPHP/ruleset.xml
+++ b/src/Standards/AcquiaPHP/ruleset.xml
@@ -86,9 +86,9 @@
   </rule>
 
   <!-- PHP Compatibility sniffs -->
-  <!-- Use the lowest version of PHP supported by Drupal.
+  <!-- Use the lowest version of PHP supported by Drupal and Acquia.
     @see https://www.drupal.org/docs/8/system-requirements/php-requirements -->
-  <config name="testVersion" value="7.1-"/>
+  <config name="testVersion" value="7.3-"/>
   <rule ref="PHPCompatibility">
     <exclude name="PHPCompatibility.Extensions.RemovedExtensions.famRemoved"/>
   </rule>

--- a/src/Standards/AcquiaPHP/ruleset.xml
+++ b/src/Standards/AcquiaPHP/ruleset.xml
@@ -86,8 +86,8 @@
   </rule>
 
   <!-- PHP Compatibility sniffs -->
-  <!-- Use the lowest version of PHP supported by Drupal and Acquia.
-    @see https://www.drupal.org/docs/8/system-requirements/php-requirements -->
+  <!-- Use the lowest version of PHP recommended for Drupal.
+    @see https://www.drupal.org/docs/system-requirements/php-requirements -->
   <config name="testVersion" value="7.3-"/>
   <rule ref="PHPCompatibility">
     <exclude name="PHPCompatibility.Extensions.RemovedExtensions.famRemoved"/>


### PR DESCRIPTION
Although Drupal technically supports PHP 7.1 still, it's very EOL and not supported by Acquia. Therefore, I don't think it should be supported in our code standards.

The problem is that if we support PHP 7.1, then we can't use some newer language features. For instance, declaring an `object` return type results in a PHP compatibility checker error:
> object return type is not present in PHP version 7.1 or earlier

I guess it depends on how strictly we want to adhere to the Drupal spec. Although none of Acquia's services support PHP 7.1, it's unclear whether an Acquia Drupal module should support PHP 7.1.