### PR TITLE
PHPCS exclude pattern warning

### DIFF
--- a/example/phpcs.xml.dist
+++ b/example/phpcs.xml.dist
@@ -15,6 +15,9 @@
 
   <file>.</file>
 
+  <!-- Danger! Exclude patterns apply to the full file path, including parent directories of the current repository. -->
+  <!-- Don't exclude common directory names like `build`, which will fail on Travis CI because of /home/travis/build/acquia/<project>. -->
+  <!-- @see https://github.com/squizlabs/PHP_CodeSniffer/issues/981 -->
   <exclude-pattern>vendor/*</exclude-pattern>
 
   <rule ref="AcquiaDrupalStrict"/>

--- a/example/phpcs.xml.dist
+++ b/example/phpcs.xml.dist
@@ -16,7 +16,7 @@
   <file>.</file>
 
   <!-- Danger! Exclude patterns apply to the full file path, including parent directories of the current repository. -->
-  <!-- Don't exclude common directory names like `build`, which will fail on Travis CI because of /home/travis/build/acquia/<project>. -->
+  <!-- Don't exclude common directory names like `build`, which would fail on Travis CI because of /home/travis/build/acquia/<project>. -->
   <!-- @see https://github.com/squizlabs/PHP_CodeSniffer/issues/981 -->
   <exclude-pattern>vendor/*</exclude-pattern>
 


### PR DESCRIPTION
I just spent hours debugging why Acquia CLI builds aren't running PHPCS properly, turns out it's due to https://github.com/squizlabs/PHP_CodeSniffer/issues/981