### PR TITLE
Fix #18: Correct extensions not scanned, allow extensions to be overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,20 +57,24 @@ Rules are split into rulesets according to the project language and framework:
 1. Check code for standards compliance:
 
     ```bash
-    ./vendor/bin/phpcs --standard=AcquiaDrupalStrict path/to/code
+    ./vendor/bin/phpcs --standard=AcquiaDrupalStrict --extensions=php,module,inc,install,test,profile,theme,css,info,txt,md,yml path/to/code
     ```
     
     Automatically fix any standards violations possible:
 
     ```bash
-    ./vendor/bin/phpcbf --standard=AcquiaDrupalStrict path/to/code
+    ./vendor/bin/phpcbf --standard=AcquiaDrupalStrict --extensions=php,module,inc,install,test,profile,theme,css,info,txt,md,yml path/to/code
     ```
+   
+    The `--extensions` argument must match the chosen code standard. For AcquiaPHP, use `--extensions=php,inc,test,css,txt,md,yml`.
     
 1. Optionally create a [default configuration file](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file) for your project so you don't have to provide the command-line arguments every time (i.e., below). Here's a working example: [`example/phpcs.xml.dist`](example/phpcs.xml.dist).
 
     ```bash
     ./vendor/bin/phpcs
     ```
+   
+    Modify `phpcs.xml.dist` to suit your project, especially to set the preferred code standard and matching extensions.
 
 1. Optionally add code checking to your [Git pre-commit hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) to prevent committing code with violations. Since client-side Git hooks are not copied when a repository is cloned, you might like to use an automated solution like [`BrainMaestro/composer-git-hooks`](https://packagist.org/packages/BrainMaestro/composer-git-hooks) to manage them, for example: [`example/composer.json`](example/composer.json).
 

--- a/example/phpcs.xml.dist
+++ b/example/phpcs.xml.dist
@@ -5,9 +5,12 @@
 
   <description>An example PHP CodeSniffer configuration.</description>
 
-  <!-- Set extensions to scan (taken from Coder 8.3.6). -->
+  <!-- Set extensions to scan. Uncomment for the respective standard. -->
   <!-- @see https://git.drupalcode.org/project/coder/blob/8.3.6/coder_sniffer/Drupal/ruleset.xml#L8 -->
+  <!-- AcquiaDrupalStrict and AcquiaDrupalTransitional -->
   <arg name="extensions" value="php,module,inc,install,test,profile,theme,css,info,txt,md,yml"/>
+  <!-- AcquiaPHP -->
+  <!-- <arg name="extensions" value="php,inc,test,css,txt,md,yml"/> -->
 
   <arg name="colors"/>
   <arg name="cache" value=".phpcs-cache"/>
@@ -20,6 +23,9 @@
   <!-- @see https://github.com/squizlabs/PHP_CodeSniffer/issues/981 -->
   <exclude-pattern>vendor/*</exclude-pattern>
 
+  <!-- If you change the standard, be sure to also update the extensions to scan -->
   <rule ref="AcquiaDrupalStrict"/>
+  <!-- <rule ref="AcquiaDrupalTransitional"/> -->
+  <!-- <rule ref="AcquiaPHP"/> -->
 
 </ruleset>

--- a/src/Standards/AcquiaDrupalStrict/ruleset.xml
+++ b/src/Standards/AcquiaDrupalStrict/ruleset.xml
@@ -8,8 +8,6 @@
 
   <description>Acquia's strict Drupal coding standards.</description>
 
-  <arg name="extensions" value="php,module,inc,install,test,profile,theme,css,info,txt,md,yml"/>
-
   <!-- Drupal sniffs -->
   <rule ref="Drupal">
     <exclude name="Drupal.Files.TxtFileLineLength.TooLong"/>

--- a/src/Standards/AcquiaDrupalTransitional/ruleset.xml
+++ b/src/Standards/AcquiaDrupalTransitional/ruleset.xml
@@ -8,8 +8,6 @@
 
   <description>Acquia's transitional Drupal coding standards.</description>
 
-  <arg name="extensions" value="php,module,inc,install,test,profile,theme,css,info,txt,md,yml"/>
-
   <!-- Drupal sniffs -->
   <rule ref="Drupal">
     <exclude name="Drupal.Files.TxtFileLineLength.TooLong"/>

--- a/src/Standards/AcquiaPHP/ruleset.xml
+++ b/src/Standards/AcquiaPHP/ruleset.xml
@@ -8,8 +8,6 @@
 
   <description>Acquia's PHP coding standards.</description>
 
-  <arg name="extensions" value="php,inc,test,css,txt,md,yml"/>
-
   <!-- Drupal sniffs -->
   <rule ref="Drupal.WhiteSpace.ScopeIndent"/>
 


### PR DESCRIPTION
Fixes #18 

I'm torn as to whether this should be released as a minor or major (i.e. BC-breaking) change. It is most certainly BC-breaking, and the failure mode is not good: if users aren't already specifying the extensions to scan and they update to this release, PHPCS will silently fail to scan some file types.

On the other hand, some file types are already being silently ignored for at least some users: that's the whole point of #18.

On the whole, I think we should make it a minor release but make sure to include this in the release notes.