### PR TITLE
Fix #9: Disallow superglobal variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Acquia Coding Standards for PHP includes a selection of sniffs from the followin
 Rules are split into rulesets according to the project language and framework:
 
 * [AcquiaPHP](src/Standards/AcquiaPHP/ruleset.xml) contains sniffs applicable to all PHP projects.
-* [AcquiaDrupalStrict](src/Standards/AcquiaDrupalStrict/ruleset.xml) incorporates AcquiaPHP and adds all Drupal coding standards and best practices sniffs. It is recommended for new Drupal projects and teams familiar with Drupal coding standards.
-* [AcquiaDrupalTransitional](src/Standards/AcquiaDrupalTransitional/ruleset.xml) provides a relaxed standard for legacy Drupal codebases or teams new to Drupal coding standards. It incorporates AcquiaPHP and adds a more or less straight copy of Drupal core's own phpcs configuration, making it sufficient for core contribution.
-* [AcquiaEdge](src/Standards/AcquiaEdge/ruleset.xml) contains new and changed sniffs that will be added to one of the other rulesets with the next major release of this package. 
+* [AcquiaDrupalStrict](src/Standards/AcquiaDrupalStrict/ruleset.xml) incorporates AcquiaPHP and adds all Drupal coding standards and best practices sniffs. Recommended for new Drupal projects and teams familiar with Drupal coding standards.
+* [AcquiaDrupalTransitional](src/Standards/AcquiaDrupalTransitional/ruleset.xml) incorporates AcquiaPHP and adds Drupal core's own phpcs configuration, which is less strict than the official standards. Recommended for legacy Drupal codebases or teams new to Drupal coding standards.
+* [AcquiaEdge](src/Standards/AcquiaEdge/ruleset.xml) incorporates AcquiaPHP and adds backwards-incompatible sniffs that will be included in AcquiaPHP with the next major release of this package. 
 
 ## Installation & usage
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Rules are split into rulesets according to the project language and framework:
 * [AcquiaPHP](src/Standards/AcquiaPHP/ruleset.xml) contains sniffs applicable to all PHP projects.
 * [AcquiaDrupalStrict](src/Standards/AcquiaDrupalStrict/ruleset.xml) incorporates AcquiaPHP and adds all Drupal coding standards and best practices sniffs. It is recommended for new Drupal projects and teams familiar with Drupal coding standards.
 * [AcquiaDrupalTransitional](src/Standards/AcquiaDrupalTransitional/ruleset.xml) provides a relaxed standard for legacy Drupal codebases or teams new to Drupal coding standards. It incorporates AcquiaPHP and adds a more or less straight copy of Drupal core's own phpcs configuration, making it sufficient for core contribution.
+* [AcquiaEdge](src/Standards/AcquiaEdge/ruleset.xml) contains new and changed sniffs that will be added to one of the other rulesets with the next major release of this package. 
 
 ## Installation & usage
 

--- a/example/phpcs.xml.dist
+++ b/example/phpcs.xml.dist
@@ -10,6 +10,7 @@
   <rule ref="AcquiaDrupalStrict"/><arg name="extensions" value="php,module,inc,install,test,profile,theme,css,info,txt,md,yml"/>
   <!-- <rule ref="AcquiaDrupalTransitional"/><arg name="extensions" value="php,module,inc,install,test,profile,theme,css,info,txt,md,yml"/> -->
   <!-- <rule ref="AcquiaPHP"/><arg name="extensions" value="php,inc,test,css,txt,md,yml"/> -->
+  <!-- <rule ref="AcquiaEdge"/><arg name="extensions" value="php,inc,test,css,txt,md,yml"/> -->
 
   <arg name="colors"/>
   <arg name="cache" value=".phpcs-cache"/>

--- a/src/Standards/AcquiaEdge/ruleset.xml
+++ b/src/Standards/AcquiaEdge/ruleset.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-Ruleset -->
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../vendor/squizlabs/php_codesniffer/phpcs.xsd"
+         name="AcquiaEdge"
+>
+
+  <description>Acquia's Edge (backwards-incompatible) coding standards.</description>
+
+  <arg name="extensions" value="php,inc,test,css,txt,md,yml"/>
+
+  <!-- SlevomatCodingStandard sniffs -->
+  <rule ref="SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable" />
+
+  <!-- Acquia PHP sniffs -->
+  <rule ref="AcquiaPHP"/>
+
+</ruleset>

--- a/src/Standards/AcquiaPHP/ruleset.xml
+++ b/src/Standards/AcquiaPHP/ruleset.xml
@@ -104,6 +104,7 @@
 
   <!-- SlevomatCodingStandard sniffs -->
   <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses" />
+  <rule ref="SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable" />
 
   <!-- Squiz sniffs -->
   <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>

--- a/src/Standards/AcquiaPHP/ruleset.xml
+++ b/src/Standards/AcquiaPHP/ruleset.xml
@@ -104,7 +104,6 @@
 
   <!-- SlevomatCodingStandard sniffs -->
   <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses" />
-  <rule ref="SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable" />
 
   <!-- Squiz sniffs -->
   <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>


### PR DESCRIPTION
Fix #9 

@TravisCarden do you think this warrants a major release? We should have a written policy on this. My feeling is that new standards likely to fail on existing projects should be considered backwards-incompatible.