### PR TITLE
Fix custom job

### DIFF
--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -45,6 +45,7 @@ jobs:
 
           # Custom job
           - php-version: "7.3"
+            orca-job: ""
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
I'm pretty sure this job isn't running because of quirks in GH Actions. ORCA_JOB needs to be explicitly set even if it's just an empty string, per my comment at https://github.com/acquia/orca/blob/97754a98c917f492e208e3b6cd6dc0409522e3d6/example/.github/workflows/orca.yml#L129-L130