### PR TITLE
Port AcquiaEdge to AcquiaPHP for 1.0 release

### DIFF
--- a/src/Standards/AcquiaEdge/ruleset.xml
+++ b/src/Standards/AcquiaEdge/ruleset.xml
@@ -8,14 +8,6 @@
 
   <description>Acquia's Edge (backwards-incompatible) coding standards.</description>
 
-  <arg name="extensions" value="php,inc,test,css,txt,md,yml"/>
-
-  <!-- Generic sniffs -->
-  <rule ref="Generic.Files.EndFileNewline" />
-
-  <!-- SlevomatCodingStandard sniffs -->
-  <rule ref="SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable" />
-
   <!-- Acquia PHP sniffs -->
   <rule ref="AcquiaPHP"/>
 

--- a/src/Standards/AcquiaPHP/ruleset.xml
+++ b/src/Standards/AcquiaPHP/ruleset.xml
@@ -14,6 +14,7 @@
   <!-- Generic sniffs -->
   <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
   <rule ref="Generic.Files.ByteOrderMark"/>
+  <rule ref="Generic.Files.EndFileNewline" />
   <rule ref="Generic.Files.LineEndings"/>
   <rule ref="Generic.Formatting.SpaceAfterCast"/>
   <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
@@ -105,6 +106,7 @@
 
   <!-- SlevomatCodingStandard sniffs -->
   <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses" />
+  <rule ref="SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable" />
 
   <!-- Squiz sniffs -->
   <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>


### PR DESCRIPTION
AcquiaEdge contains new rules that should be moved to AcquiaPHP with each major release. Since this has been stable for a while, let's do that now and cut a 1.0 release.