### PR TITLE
Add Drupal.ControlStructures.ControlSignature to AcquiaPHP

### DIFF
--- a/src/Standards/AcquiaEdge/ruleset.xml
+++ b/src/Standards/AcquiaEdge/ruleset.xml
@@ -13,5 +13,7 @@
 
   <!-- Drupal sniffs -->
   <rule ref="Drupal.Classes.UnusedUseStatement"/>
+  <!-- https://www.php-fig.org/psr/psr-12/#5-control-structures -->
+  <rule ref="Drupal.ControlStructures.ControlSignature" />
 
 </ruleset>


### PR DESCRIPTION
PSR-12 requires certain control structure styles that are not enforced today, such as spaces after keywords (e.g. `if (` instead of `if(`)

https://www.php-fig.org/psr/psr-12/#5-control-structures