### PR TITLE
Added support of 8 version of slevomat/coding-standard.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "drupal/coder": "^8.3.7",
         "phpcompatibility/php-compatibility": "^9.0",
-        "slevomat/coding-standard": "^7.0",
+        "slevomat/coding-standard": "^7.0 || ^8.0",
         "squizlabs/php_codesniffer": "^3"
     },
     "suggest": {


### PR DESCRIPTION
We are fixing the CI job failure due to slevomat/coding-standard locked at 7.2.1

Ticket reference: https://backlog.acquia.com/browse/ACMS-1366