### PR TITLE
ORCA-411: Enable D10 Jobs

### DIFF
--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -44,8 +44,6 @@ jobs:
           - ISOLATED_TEST_ON_NEXT_MINOR_DEV
           - INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR_DEV
           - LOOSE_DEPRECATED_CODE_SCAN
-          - ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
-          - INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
         php-version: [ "7.4" ]
         coveralls-enable: [ "FALSE" ]
         include:
@@ -58,6 +56,12 @@ jobs:
           - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
             php-version: "8.1"
             coveralls-enable: "FALSE"
+          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
+            php-version: "8.1"
+            coveralls-enable: "FALSE"
+          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
+            php-version: "8.1"
+            coveralls-enable: "FALSE"  
           - orca-job: ISOLATED_TEST_ON_CURRENT
             php-version: "8.0"
             coveralls-enable: "FALSE"

--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -44,10 +44,18 @@ jobs:
           - ISOLATED_TEST_ON_NEXT_MINOR_DEV
           - INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR_DEV
           - LOOSE_DEPRECATED_CODE_SCAN
+          - ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+          - INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
         php-version: [ "7.4" ]
         coveralls-enable: [ "FALSE" ]
         include:
           - orca-job: ISOLATED_TEST_ON_CURRENT
+            php-version: "8.1"
+            coveralls-enable: "FALSE"
+          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+            php-version: "8.1"
+            coveralls-enable: "FALSE"
+          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
             php-version: "8.1"
             coveralls-enable: "FALSE"
           - orca-job: ISOLATED_TEST_ON_CURRENT


### PR DESCRIPTION
**Motivation**
Enables jobs to test D10 readiness . [ORCA-411](https://backlog.acquia.com/browse/ORCA-411)

**Proposed changes**
Enabled the following jobs
1. ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
2. INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
3. ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
4. INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER