### PR TITLE
ORCA-488: D10 readiness

### DIFF
--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -26,47 +26,55 @@ jobs:
         orca-job:
           - STATIC_CODE_ANALYSIS
           - INTEGRATED_TEST_ON_OLDEST_SUPPORTED
-          - INTEGRATED_TEST_ON_LATEST_LTS
+          # - INTEGRATED_TEST_ON_LATEST_LTS
           - INTEGRATED_TEST_ON_PREVIOUS_MINOR
-          - INTEGRATED_UPGRADE_TEST_FROM_PREVIOUS_MINOR
+          # - INTEGRATED_UPGRADE_TEST_FROM_PREVIOUS_MINOR
           - ISOLATED_TEST_ON_CURRENT
           - INTEGRATED_TEST_ON_CURRENT
-          - INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR
+          # - INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR
           - ISOLATED_TEST_ON_CURRENT_DEV
           - INTEGRATED_TEST_ON_CURRENT_DEV
           - STRICT_DEPRECATED_CODE_SCAN
           - ISOLATED_TEST_ON_NEXT_MINOR
           - INTEGRATED_TEST_ON_NEXT_MINOR
-          - ISOLATED_UPGRADE_TEST_TO_NEXT_MAJOR_BETA_OR_LATER
-          - ISOLATED_UPGRADE_TEST_TO_NEXT_MAJOR_DEV
+          # - ISOLATED_UPGRADE_TEST_TO_NEXT_MAJOR_BETA_OR_LATER
+          # - ISOLATED_UPGRADE_TEST_TO_NEXT_MAJOR_DEV
           - DEPRECATED_CODE_SCAN_W_CONTRIB
           - INTEGRATED_TEST_ON_NEXT_MINOR_DEV
           - ISOLATED_TEST_ON_NEXT_MINOR_DEV
-          - INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR_DEV
+          # - INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR_DEV
           - LOOSE_DEPRECATED_CODE_SCAN
-        php-version: [ "7.4" ]
+        php-version: [ "8.1" ]
         coveralls-enable: [ "FALSE" ]
         include:
-          - orca-job: ISOLATED_TEST_ON_CURRENT
-            php-version: "8.1"
+          - orca-job: INTEGRATED_TEST_ON_OLDEST_SUPPORTED
+            php-version: "7.4"
             coveralls-enable: "FALSE"
-          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
-            php-version: "8.1"
-            coveralls-enable: "FALSE"
-          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
-            php-version: "8.1"
-            coveralls-enable: "FALSE"
-          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
-            php-version: "8.1"
-            coveralls-enable: "FALSE"
-          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
-            php-version: "8.1"
-            coveralls-enable: "FALSE"  
-          - orca-job: ISOLATED_TEST_ON_CURRENT
+
+          - orca-job: INTEGRATED_TEST_ON_OLDEST_SUPPORTED
             php-version: "8.0"
             coveralls-enable: "FALSE"
+
+          - orca-job: INTEGRATED_TEST_ON_LATEST_LTS
+            php-version: "7.4"
+            coveralls-enable: "FALSE"
+          # - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+          #   php-version: "8.1"
+          #   coveralls-enable: "FALSE"
+          # - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+          #   php-version: "8.1"
+          #   coveralls-enable: "FALSE"
+          # - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
+          #   php-version: "8.1"
+          #   coveralls-enable: "FALSE"
+          # - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
+          #   php-version: "8.1"
+          #   coveralls-enable: "FALSE"
+          # - orca-job: ISOLATED_TEST_ON_CURRENT
+          #   php-version: "8.0"
+          #   coveralls-enable: "FALSE"
           # Custom job
-          - php-version: "7.4"
+          - php-version: "8.1"
             orca-job: ""
 
     steps:

--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       ORCA_SUT_NAME: acquia/coding-standards
       ORCA_SUT_BRANCH: master
-      ORCA_VERSION: ^3
+      ORCA_VERSION: 3.26.0
       ORCA_TELEMETRY_ENABLE: TRUE
       ORCA_JOB: ${{ matrix.orca-job }}
       ORCA_COVERALLS_ENABLE: ${{ matrix.coveralls-enable }}


### PR DESCRIPTION
Details [ORCA-488](https://backlog.acquia.com/browse/ORCA-488)

- Use appropriate versions of php
- Point to ORCA 3.26.0 for D10 tests