### PR TITLE
Add strict typehinting to edge

### DIFF
--- a/src/Standards/AcquiaEdge/ruleset.xml
+++ b/src/Standards/AcquiaEdge/ruleset.xml
@@ -18,5 +18,12 @@
   <!-- https://www.php-fig.org/psr/psr-12/#5-control-structures -->
   <rule ref="Drupal.ControlStructures.ControlSignature" />
   <rule ref="PSR12.Functions.ReturnTypeDeclaration" />
+  <rule ref="Drupal.Scope.MethodScope"/>
+  <rule ref="Drupal.Scope.MethodScope"/>
+
+  <!-- SlevomatCodingStandard sniffs -->
+  <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint" />
+  <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint" />
+  <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint" />
 
 </ruleset>

--- a/src/Standards/AcquiaPHP/ruleset.xml
+++ b/src/Standards/AcquiaPHP/ruleset.xml
@@ -9,6 +9,7 @@
   <description>Acquia's PHP coding standards.</description>
 
   <!-- Drupal sniffs -->
+  <!-- These provide PHPCBF integration, unlike their Squiz equivalents -->
   <rule ref="Drupal.WhiteSpace.ScopeIndent"/>
 
   <!-- Generic sniffs -->


### PR DESCRIPTION
I consider strict typehinting to be a best practice. We should adopt this in all of our projects. I'm adding this to edge since it's a heavy lift to adopt for existing projects without typehinting.

It might be such a large effort that we want to put it in a standalone "StrictTypes" standard or something.

I think there's also a Slevomat sniff to enforce the use of `declare(strict_types=1)` in every file, if we want to take it that far.