### PR TITLE
Operator spacing sniff

### DIFF
--- a/src/Standards/AcquiaPHP/ruleset.xml
+++ b/src/Standards/AcquiaPHP/ruleset.xml
@@ -210,6 +210,7 @@
     </properties>
   </rule>
   <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
+  <rule ref="Squiz.WhiteSpace.OperatorSpacing" />
   <rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
   <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
 


### PR DESCRIPTION
Prevents ugliness like `if ($a=='b') {`