### PR TITLE
PhpStorm separate profile

### DIFF
--- a/example/PhpStormInspections.xml
+++ b/example/PhpStormInspections.xml
@@ -7,11 +7,12 @@ Import this file on PhpStorm's inspection settings screen to set up default PHP 
 
 -->
 <profile version="1.0">
-  <option name="myName" value="Default" />
+  <option name="myName" value="Acquia Coding Standards" />
   <inspection_tool class="PhpCSValidationInspection" enabled="false" level="WARNING" enabled_by_default="false">
     <option name="EXTENSIONS" value="php,module,inc,install,test,profile,theme,css,info,txt,md,yml" />
   </inspection_tool>
   <inspection_tool class="PhpDocSignatureInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
     <option name="ALLOW_MISSING_PARAMETERS" value="true" />
   </inspection_tool>
+  <inspection_tool class="PhpDocMissingThrowsInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
 </profile>

--- a/example/PhpStormInspections.xml
+++ b/example/PhpStormInspections.xml
@@ -8,7 +8,7 @@ Import this file on PhpStorm's inspection settings screen to set up default PHP 
 -->
 <profile version="1.0">
   <option name="myName" value="Acquia Coding Standards" />
-  <inspection_tool class="PhpCSValidationInspection" enabled="false" level="WARNING" enabled_by_default="false">
+  <inspection_tool class="PhpCSValidationInspection" enabled="true" level="WARNING" enabled_by_default="true">
     <option name="EXTENSIONS" value="php,module,inc,install,test,profile,theme,css,info,txt,md,yml" />
   </inspection_tool>
   <inspection_tool class="PhpDocSignatureInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">

--- a/example/PhpStormInspections.xml
+++ b/example/PhpStormInspections.xml
@@ -14,5 +14,4 @@ Import this file on PhpStorm's inspection settings screen to set up default PHP 
   <inspection_tool class="PhpDocSignatureInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
     <option name="ALLOW_MISSING_PARAMETERS" value="true" />
   </inspection_tool>
-  <inspection_tool class="PhpDocMissingThrowsInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
 </profile>


### PR DESCRIPTION
Our code standards forbid throws tags since they quickly become stale.

Additionally, I'm testing whether it's better to import the PhpStorm inspections profile as a separate profile rather than clobbering the default one, which might not be nice if folks do more than just Acquia / Drupal development.