### PR TITLE
Fix #61: Exclude .module files from type hint requirements

### DIFF
--- a/src/Standards/AcquiaDrupalStrict/ruleset.xml
+++ b/src/Standards/AcquiaDrupalStrict/ruleset.xml
@@ -38,16 +38,16 @@
   <!-- Drupal should type hint hooks -->
   <!-- @see https://www.drupal.org/project/drupal/issues/3229216 -->
   <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification">
-    <exclude-pattern>docroot/modules/custom/*/*.module</exclude-pattern>
+    <exclude-pattern>*/modules/custom/*/*\.(module|install)$</exclude-pattern>
   </rule>
   <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingAnyTypeHint">
-    <exclude-pattern>docroot/modules/custom/*/*.module</exclude-pattern>
+    <exclude-pattern>*/modules/custom/*/*\.(module|install)$</exclude-pattern>
   </rule>
   <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint">
-    <exclude-pattern>docroot/modules/custom/*/*.module</exclude-pattern>
+    <exclude-pattern>*/modules/custom/*/*\.(module|install)$</exclude-pattern>
   </rule>
   <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification">
-    <exclude-pattern>docroot/modules/custom/*/*.module</exclude-pattern>
+    <exclude-pattern>*/modules/custom/*/*\.(module|install)$</exclude-pattern>
   </rule>
 
 </ruleset>

--- a/src/Standards/AcquiaDrupalStrict/ruleset.xml
+++ b/src/Standards/AcquiaDrupalStrict/ruleset.xml
@@ -35,4 +35,19 @@
   <!-- Acquia PHP sniffs -->
   <rule ref="AcquiaPHP"/>
 
+  <!-- Drupal should type hint hooks -->
+  <!-- @see https://www.drupal.org/project/drupal/issues/3229216 -->
+  <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification">
+    <exclude-pattern>docroot/modules/custom/*/*.module</exclude-pattern>
+  </rule>
+  <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingAnyTypeHint">
+    <exclude-pattern>docroot/modules/custom/*/*.module</exclude-pattern>
+  </rule>
+  <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint">
+    <exclude-pattern>docroot/modules/custom/*/*.module</exclude-pattern>
+  </rule>
+  <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification">
+    <exclude-pattern>docroot/modules/custom/*/*.module</exclude-pattern>
+  </rule>
+
 </ruleset>

--- a/src/Standards/AcquiaDrupalTransitional/ruleset.xml
+++ b/src/Standards/AcquiaDrupalTransitional/ruleset.xml
@@ -38,16 +38,16 @@
   <!-- Drupal should type hint hooks -->
   <!-- @see https://www.drupal.org/project/drupal/issues/3229216 -->
   <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification">
-    <exclude-pattern>docroot/modules/custom/*/*.module</exclude-pattern>
+    <exclude-pattern>*/modules/custom/*/*\.(module|install)$</exclude-pattern>
   </rule>
   <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingAnyTypeHint">
-    <exclude-pattern>docroot/modules/custom/*/*.module</exclude-pattern>
+    <exclude-pattern>*/modules/custom/*/*\.(module|install)$</exclude-pattern>
   </rule>
   <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint">
-    <exclude-pattern>docroot/modules/custom/*/*.module</exclude-pattern>
+    <exclude-pattern>*/modules/custom/*/*\.(module|install)$</exclude-pattern>
   </rule>
   <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification">
-    <exclude-pattern>docroot/modules/custom/*/*.module</exclude-pattern>
+    <exclude-pattern>*/modules/custom/*/*\.(module|install)$</exclude-pattern>
   </rule>
 
 </ruleset>

--- a/src/Standards/AcquiaDrupalTransitional/ruleset.xml
+++ b/src/Standards/AcquiaDrupalTransitional/ruleset.xml
@@ -35,4 +35,19 @@
   <!-- Acquia PHP sniffs -->
   <rule ref="AcquiaPHP"/>
 
+  <!-- Drupal should type hint hooks -->
+  <!-- @see https://www.drupal.org/project/drupal/issues/3229216 -->
+  <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification">
+    <exclude-pattern>docroot/modules/custom/*/*.module</exclude-pattern>
+  </rule>
+  <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingAnyTypeHint">
+    <exclude-pattern>docroot/modules/custom/*/*.module</exclude-pattern>
+  </rule>
+  <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint">
+    <exclude-pattern>docroot/modules/custom/*/*.module</exclude-pattern>
+  </rule>
+  <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification">
+    <exclude-pattern>docroot/modules/custom/*/*.module</exclude-pattern>
+  </rule>
+
 </ruleset>


### PR DESCRIPTION
I add these exclusions grudgingly. Drupal needs to type hint its hooks: https://www.drupal.org/project/drupal/issues/3229216

There's no reason end users can't type hint hooks themselves, but I understand why one wouldn't want to depart from the standard, broken though it may be.