### PR TITLE
Switch Acquia PHP to PSR12

### DIFF
--- a/.github/script.sh
+++ b/.github/script.sh
@@ -54,7 +54,7 @@ if [[ "$FAILURES" ]]; then
 fi
 
 # Place a good test file.
-printf "<?php\n\n/**\n * @file\n * Good test file.\n */\n" > good.php
+printf "<?php\n\ndeclare(strict_types = 1);\n\n/**\n * @file\n * Good test file.\n */\n" > good.php
 
 # Test that the SUT's standards can be run.
 EXPECTED=(

--- a/.github/script.sh
+++ b/.github/script.sh
@@ -54,7 +54,7 @@ if [[ "$FAILURES" ]]; then
 fi
 
 # Place a good test file.
-printf "<?php\n\n/**\n * @file\n * Good test file.\n */\n\ndeclare(strict_types = 1);\n" > good.php
+printf "<?php\n\n/**\n * @file\n * Good test file.\n */\n\ndeclare(strict_types=1);\n" > good.php
 
 # Test that the SUT's standards can be run.
 EXPECTED=(

--- a/.github/script.sh
+++ b/.github/script.sh
@@ -54,7 +54,7 @@ if [[ "$FAILURES" ]]; then
 fi
 
 # Place a good test file.
-printf "<?php\n\ndeclare(strict_types = 1);\n\n/**\n * @file\n * Good test file.\n */\n" > good.php
+printf "<?php\n\n/**\n * @file\n * Good test file.\n */\n\ndeclare(strict_types=1);\n" > good.php
 
 # Test that the SUT's standards can be run.
 EXPECTED=(

--- a/.github/script.sh
+++ b/.github/script.sh
@@ -54,7 +54,7 @@ if [[ "$FAILURES" ]]; then
 fi
 
 # Place a good test file.
-printf "<?php\n\n/**\n * @file\n * Good test file.\n */\n\ndeclare(strict_types=1);\n" > good.php
+printf "<?php\n\n/**\n * @file\n * Good test file.\n */\n\ndeclare(strict_types = 1);\n" > good.php
 
 # Test that the SUT's standards can be run.
 EXPECTED=(

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Acquia Coding Standards for PHP includes a selection of sniffs from the followin
 
 Rules are split into rulesets according to the project language and framework:
 
-* [AcquiaPHP](src/Standards/AcquiaPHP/ruleset.xml) contains sniffs applicable to all PHP projects.
-* [AcquiaDrupalStrict](src/Standards/AcquiaDrupalStrict/ruleset.xml) incorporates AcquiaPHP and adds all Drupal coding standards and best practices sniffs. Recommended for new Drupal projects and teams familiar with Drupal coding standards.
-* [AcquiaDrupalTransitional](src/Standards/AcquiaDrupalTransitional/ruleset.xml) incorporates AcquiaPHP and adds Drupal core's own phpcs configuration, which is less strict than the official standards. Recommended for legacy Drupal codebases or teams new to Drupal coding standards.
+* [AcquiaPHP](src/Standards/AcquiaPHP/ruleset.xml) is the preferred standard for all Acquia projects, including Drupal projects. It is based on PSR-12 and compatible with Drupal standards. In other words, any code meeting the AcquiaPHP standard will also meet Drupal standards, but will take advantage of new language features offered by PSR-12 and (soon) PER-2.
+* [AcquiaDrupalStrict](src/Standards/AcquiaDrupalStrict/ruleset.xml) is based on Drupal coding standards and best practices sniffs. Recommended for legacy Drupal projects and teams familiar with Drupal coding standards that don't want to use the stricter AcquiaPHP standard.
+* [AcquiaDrupalTransitional](src/Standards/AcquiaDrupalTransitional/ruleset.xml) is based on Drupal core's own phpcs configuration, which is less strict than the official standards. Recommended for legacy Drupal codebases or teams new to Drupal coding standards.
 * [AcquiaEdge](src/Standards/AcquiaEdge/ruleset.xml) incorporates AcquiaPHP and adds backwards-incompatible sniffs that will be included in AcquiaPHP with the next major release of this package.
 
 ## Installation & usage

--- a/composer.lock
+++ b/composer.lock
@@ -86,30 +86,30 @@
         },
         {
             "name": "drupal/coder",
-            "version": "8.3.18",
+            "version": "8.3.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pfrenssen/coder.git",
-                "reference": "d5911f812b69ca3bda5524899bdd06b3b4e687ff"
+                "reference": "1a1613d83c08dac5be593f2775c9eccae1b41805"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pfrenssen/coder/zipball/d5911f812b69ca3bda5524899bdd06b3b4e687ff",
-                "reference": "d5911f812b69ca3bda5524899bdd06b3b4e687ff",
+                "url": "https://api.github.com/repos/pfrenssen/coder/zipball/1a1613d83c08dac5be593f2775c9eccae1b41805",
+                "reference": "1a1613d83c08dac5be593f2775c9eccae1b41805",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1 || ^1.0.0",
                 "ext-mbstring": "*",
-                "php": ">=7.1",
+                "php": ">=7.2",
                 "sirbrillig/phpcs-variable-analysis": "^2.11.7",
-                "slevomat/coding-standard": "^7.0 || ^8.0",
+                "slevomat/coding-standard": "^8.11",
                 "squizlabs/php_codesniffer": "^3.7.1",
                 "symfony/yaml": ">=3.4.0"
             },
             "require-dev": {
                 "phpstan/phpstan": "^1.7.12",
-                "phpunit/phpunit": "^7.0 || ^8.0"
+                "phpunit/phpunit": "^8.0"
             },
             "type": "phpcodesniffer-standard",
             "autoload": {
@@ -133,7 +133,7 @@
                 "issues": "https://www.drupal.org/project/issues/coder",
                 "source": "https://www.drupal.org/project/coder"
             },
-            "time": "2023-04-18T12:07:59+00:00"
+            "time": "2024-01-27T18:13:12+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -199,22 +199,24 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.20.4",
+            "version": "1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "7d568c87a9df9c5f7e8b5f075fc469aa8cb0a4cd"
+                "reference": "86e4d5a4b036f8f0be1464522f4c6b584c452757"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/7d568c87a9df9c5f7e8b5f075fc469aa8cb0a4cd",
-                "reference": "7d568c87a9df9c5f7e8b5f075fc469aa8cb0a4cd",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/86e4d5a4b036f8f0be1464522f4c6b584c452757",
+                "reference": "86e4d5a4b036f8f0be1464522f4c6b584c452757",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0"
             },
             "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^4.15",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/extension-installer": "^1.0",
                 "phpstan/phpstan": "^1.5",
@@ -238,22 +240,22 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.20.4"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.27.0"
             },
-            "time": "2023-05-02T09:19:37+00:00"
+            "time": "2024-03-21T13:14:53+00:00"
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
-            "version": "v2.11.16",
+            "version": "v2.11.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "dc5582dc5a93a235557af73e523c389aac9a8e88"
+                "reference": "3b71162a6bf0cde2bff1752e40a1788d8273d049"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/dc5582dc5a93a235557af73e523c389aac9a8e88",
-                "reference": "dc5582dc5a93a235557af73e523c389aac9a8e88",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/3b71162a6bf0cde2bff1752e40a1788d8273d049",
+                "reference": "3b71162a6bf0cde2bff1752e40a1788d8273d049",
                 "shasum": ""
             },
             "require": {
@@ -298,36 +300,36 @@
                 "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
                 "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
             },
-            "time": "2023-03-31T16:46:32+00:00"
+            "time": "2023-08-05T23:46:11+00:00"
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "8.12.1",
+            "version": "8.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "f69e2524e8770efb9b3e5ac4a0ebc0d54eb446d7"
+                "reference": "7d1d957421618a3803b593ec31ace470177d7817"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/f69e2524e8770efb9b3e5ac4a0ebc0d54eb446d7",
-                "reference": "f69e2524e8770efb9b3e5ac4a0ebc0d54eb446d7",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/7d1d957421618a3803b593ec31ace470177d7817",
+                "reference": "7d1d957421618a3803b593ec31ace470177d7817",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
                 "php": "^7.2 || ^8.0",
-                "phpstan/phpdoc-parser": ">=1.20.0 <1.21.0",
-                "squizlabs/php_codesniffer": "^3.7.1"
+                "phpstan/phpdoc-parser": "^1.23.1",
+                "squizlabs/php_codesniffer": "^3.9.0"
             },
             "require-dev": {
                 "phing/phing": "2.17.4",
                 "php-parallel-lint/php-parallel-lint": "1.3.2",
-                "phpstan/phpstan": "1.10.15",
-                "phpstan/phpstan-deprecation-rules": "1.1.3",
-                "phpstan/phpstan-phpunit": "1.3.11",
-                "phpstan/phpstan-strict-rules": "1.5.1",
-                "phpunit/phpunit": "7.5.20|8.5.21|9.6.8|10.1.3"
+                "phpstan/phpstan": "1.10.60",
+                "phpstan/phpstan-deprecation-rules": "1.1.4",
+                "phpstan/phpstan-phpunit": "1.3.16",
+                "phpstan/phpstan-strict-rules": "1.5.2",
+                "phpunit/phpunit": "8.5.21|9.6.8|10.5.11"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -351,7 +353,7 @@
             ],
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/8.12.1"
+                "source": "https://github.com/slevomat/coding-standard/tree/8.15.0"
             },
             "funding": [
                 {
@@ -363,20 +365,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-15T21:42:25+00:00"
+            "time": "2024-03-09T15:20:58+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.2",
+            "version": "3.9.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "d63cee4890a8afaf86a22e51ad4d97c91dd4579b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/d63cee4890a8afaf86a22e51ad4d97c91dd4579b",
+                "reference": "d63cee4890a8afaf86a22e51ad4d97c91dd4579b",
                 "shasum": ""
             },
             "require": {
@@ -386,11 +388,11 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
+                "bin/phpcbf",
+                "bin/phpcs"
             ],
             "type": "library",
             "extra": {
@@ -405,35 +407,125 @@
             "authors": [
                 {
                     "name": "Greg Sherwood",
-                    "role": "lead"
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards",
                 "static analysis"
             ],
             "support": {
-                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
-                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
-                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
             },
-            "time": "2023-02-22T23:07:41+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-02-16T15:06:51+00:00"
         },
         {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.27.0",
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a"
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/5bbc823adecdae860bb64756d639ecfec17b050a",
-                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/7c3aff79d10325257a001fcf92d991f24fc967cf",
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.4-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-05-23T14:45:45+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.29.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "ef4d7e442ca910c4764bce785146269b30cb5fc4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ef4d7e442ca910c4764bce785146269b30cb5fc4",
+                "reference": "ef4d7e442ca910c4764bce785146269b30cb5fc4",
                 "shasum": ""
             },
             "require": {
@@ -447,9 +539,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -486,7 +575,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -502,34 +591,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v6.2.10",
+            "version": "v6.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "61916f3861b1e9705b18cfde723921a71dd1559d"
+                "reference": "d75715985f0f94f978e3a8fa42533e10db921b90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/61916f3861b1e9705b18cfde723921a71dd1559d",
-                "reference": "61916f3861b1e9705b18cfde723921a71dd1559d",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/d75715985f0f94f978e3a8fa42533e10db921b90",
+                "reference": "d75715985f0f94f978e3a8fa42533e10db921b90",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
                 "symfony/console": "<5.4"
             },
             "require-dev": {
-                "symfony/console": "^5.4|^6.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
+                "symfony/console": "^5.4|^6.0|^7.0"
             },
             "bin": [
                 "Resources/bin/yaml-lint"
@@ -560,7 +647,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.2.10"
+                "source": "https://github.com/symfony/yaml/tree/v6.4.3"
             },
             "funding": [
                 {
@@ -576,7 +663,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-28T13:25:36+00:00"
+            "time": "2024-01-23T14:51:35+00:00"
         }
     ],
     "packages-dev": [],
@@ -587,5 +674,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/Standards/AcquiaDrupalStrict/ruleset.xml
+++ b/src/Standards/AcquiaDrupalStrict/ruleset.xml
@@ -32,7 +32,4 @@
   <!-- Drupal Practice sniffs -->
   <rule ref="DrupalPractice"/>
 
-  <!-- Acquia PHP sniffs -->
-  <rule ref="AcquiaPHP"/>
-
 </ruleset>

--- a/src/Standards/AcquiaDrupalTransitional/ruleset.xml
+++ b/src/Standards/AcquiaDrupalTransitional/ruleset.xml
@@ -32,7 +32,4 @@
   <!-- Drupal Practice sniffs -->
   <rule ref="DrupalPractice.Commenting.ExpectedException"/>
 
-  <!-- Acquia PHP sniffs -->
-  <rule ref="AcquiaPHP"/>
-
 </ruleset>

--- a/src/Standards/AcquiaEdge/ruleset.xml
+++ b/src/Standards/AcquiaEdge/ruleset.xml
@@ -11,8 +11,4 @@
   <!-- Acquia PHP sniffs -->
   <rule ref="AcquiaPHP"/>
 
-  <!-- SlevomatCodingStandard sniffs -->
-  <rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing" />
-  <rule ref="SlevomatCodingStandard.Commenting.EmptyComment" />
-
 </ruleset>

--- a/src/Standards/AcquiaPHP/ruleset.xml
+++ b/src/Standards/AcquiaPHP/ruleset.xml
@@ -92,7 +92,13 @@
   <rule ref="SlevomatCodingStandard.Commenting.UselessFunctionDocComment"/>
   <rule ref="SlevomatCodingStandard.Commenting.UselessInheritDocComment"/>
   <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses"/>
-  <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes"/>
+  <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
+    <properties>
+      <property name="linesCountBeforeDeclare" value="1"/>
+      <property name="linesCountAfterDeclare" value="1"/>
+      <property name="spacesCountAroundEqualsSign" value="0"/>
+    </properties>
+  </rule>
   <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
     <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification"/>
   </rule>

--- a/src/Standards/AcquiaPHP/ruleset.xml
+++ b/src/Standards/AcquiaPHP/ruleset.xml
@@ -14,6 +14,7 @@
     <exclude name="Generic.PHP.LowerCaseConstant"/>
     <exclude name="PSR2.Classes.ClassDeclaration"/>
     <exclude name="PSR2.Methods.FunctionCallSignature"/>
+    <exclude name="Squiz.ControlStructures.ControlSignature"/>
     <exclude name="Squiz.Functions.FunctionDeclaration"/>
     <exclude name="Squiz.Functions.MultiLineFunctionDeclaration"/>
   </rule>
@@ -25,6 +26,7 @@
   </rule>
 
   <!-- Drupal sniffs -->
+  <rule ref="Drupal.ControlStructures.ControlSignature"/>
   <rule ref="Drupal.Classes.UnusedUseStatement"/>
   <rule ref="Drupal.Commenting.InlineComment"/>
   <rule ref="Drupal.WhiteSpace.ScopeIndent"/>

--- a/src/Standards/AcquiaPHP/ruleset.xml
+++ b/src/Standards/AcquiaPHP/ruleset.xml
@@ -11,6 +11,8 @@
   <rule ref="PSR12">
     <exclude name="Generic.WhiteSpace.ScopeIndent"/>
     <exclude name="Generic.PHP.LowerCaseConstant"/>
+    <exclude name="PSR2.Classes.ClassDeclaration"/>
+    <exclude name="Squiz.Functions.FunctionDeclaration"/>
   </rule>
 
   <!-- Drupal sniffs -->

--- a/src/Standards/AcquiaPHP/ruleset.xml
+++ b/src/Standards/AcquiaPHP/ruleset.xml
@@ -10,25 +10,21 @@
 
   <!-- The Acquia PHP standard is PSR-12 modified to be compatible with Drupal standards -->
   <rule ref="PSR12">
-    <exclude name="Generic.WhiteSpace.ScopeIndent"/>
+    <exclude name="Generic.Files.LineLength"/>
     <exclude name="Generic.PHP.LowerCaseConstant"/>
+    <exclude name="Generic.PHP.LowerCaseType"/>
+    <exclude name="Generic.WhiteSpace.ScopeIndent"/>
     <exclude name="PSR2.Classes.ClassDeclaration"/>
-    <exclude name="PSR2.Methods.FunctionCallSignature"/>
+    <exclude name="PSR12.Classes.OpeningBraceSpace"/>
     <exclude name="Squiz.ControlStructures.ControlSignature"/>
     <exclude name="Squiz.Functions.FunctionDeclaration"/>
     <exclude name="Squiz.Functions.MultiLineFunctionDeclaration"/>
   </rule>
 
-  <rule ref="PEAR.Functions.FunctionCallSignature">
-    <properties>
-      <property name="indent" value="2"/>
-    </properties>
-  </rule>
-
   <!-- Drupal sniffs -->
-  <rule ref="Drupal.ControlStructures.ControlSignature"/>
   <rule ref="Drupal.Classes.UnusedUseStatement"/>
   <rule ref="Drupal.Commenting.InlineComment"/>
+  <rule ref="Drupal.ControlStructures.ControlSignature"/>
   <rule ref="Drupal.WhiteSpace.ScopeIndent"/>
 
   <!-- Generic sniffs -->
@@ -55,26 +51,6 @@
 
   <!-- PEAR sniffs -->
   <rule ref="PEAR.Files.IncludingFile"/>
-  <!-- Disable some error messages that we do not want. -->
-  <rule ref="PEAR.Files.IncludingFile.UseIncludeOnce">
-    <severity>0</severity>
-  </rule>
-  <rule ref="PEAR.Files.IncludingFile.UseInclude">
-    <severity>0</severity>
-  </rule>
-  <rule ref="PEAR.Files.IncludingFile.UseRequireOnce">
-    <severity>0</severity>
-  </rule>
-  <rule ref="PEAR.Files.IncludingFile.UseRequire">
-    <severity>0</severity>
-  </rule>
-
-  <!-- PSR-12 sniffs -->
-  <rule ref="PSR12.ControlStructures.ControlStructureSpacing">
-    <properties>
-      <property name="indent" value="2"/>
-    </properties>
-  </rule>
 
   <!-- PHP Compatibility sniffs -->
   <!-- The lowest version of PHP supported by both Drupal and Acquia Cloud.
@@ -85,6 +61,25 @@
   <config name="testVersion" value="7.4-"/>
   <rule ref="PHPCompatibility">
     <exclude name="PHPCompatibility.Extensions.RemovedExtensions.famRemoved"/>
+  </rule>
+
+  <!-- PSR-2 sniffs -->
+  <rule ref="PSR2.ControlStructures.SwitchDeclaration">
+    <properties>
+      <property name="indent" value="2" />
+    </properties>
+  </rule>
+  <rule ref="PSR2.Methods.FunctionCallSignature">
+    <properties>
+      <property name="indent" value="2" />
+    </properties>
+  </rule>
+
+  <!-- PSR-12 sniffs -->
+  <rule ref="PSR12.ControlStructures.ControlStructureSpacing">
+    <properties>
+      <property name="indent" value="2"/>
+    </properties>
   </rule>
 
   <!-- SlevomatCodingStandard sniffs -->
@@ -130,10 +125,7 @@
 
   <!-- Squiz sniffs -->
   <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
-  <rule ref="Squiz.Arrays.ArrayDeclaration">
-    <exclude name="Squiz.Arrays.ArrayDeclaration.NoKeySpecified"/>
-    <exclude name="Squiz.Arrays.ArrayDeclaration.KeySpecified"/>
-  </rule>
+  <rule ref="Squiz.Arrays.ArrayDeclaration" />
   <!-- Disable some error messages that we do not want. -->
   <rule ref="Squiz.Arrays.ArrayDeclaration.CloseBraceNotAligned">
     <severity>0</severity>
@@ -168,22 +160,10 @@
   <rule ref="Squiz.Arrays.ArrayDeclaration.ValueNoNewline">
     <severity>0</severity>
   </rule>
-  <rule ref="Squiz.Functions.MultiLineFunctionDeclaration" />
-  <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine">
-    <severity>0</severity>
-  </rule>
-  <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.ContentAfterBrace">
-    <severity>0</severity>
-  </rule>
-  <!-- Standard yet to be finalized on this (https://www.drupal.org/node/1539712). -->
-  <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.FirstParamSpacing">
-    <severity>0</severity>
-  </rule>
-  <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.Indent">
-    <severity>0</severity>
-  </rule>
-  <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.CloseBracketLine">
-    <severity>0</severity>
+  <rule ref="Squiz.Functions.MultiLineFunctionDeclaration">
+    <properties>
+      <property name="indent" value="2" />
+    </properties>
   </rule>
   <rule ref="Squiz.PHP.LowercasePHPFunctions"/>
   <rule ref="Squiz.Strings.ConcatenationSpacing">

--- a/src/Standards/AcquiaPHP/ruleset.xml
+++ b/src/Standards/AcquiaPHP/ruleset.xml
@@ -8,23 +8,18 @@
 
   <description>Acquia's PHP coding standards.</description>
 
+  <rule ref="PSR12">
+    <exclude name="Generic.WhiteSpace.ScopeIndent"/>
+    <exclude name="Generic.PHP.LowerCaseConstant"/>
+  </rule>
+
   <!-- Drupal sniffs -->
-  <!-- These provide PHPCBF integration, unlike their Squiz equivalents -->
-  <rule ref="Drupal.Classes.ClassDeclaration" />
   <rule ref="Drupal.Classes.UnusedUseStatement"/>
-  <!-- https://www.php-fig.org/psr/psr-12/#5-control-structures -->
-  <rule ref="Drupal.ControlStructures.ControlSignature" />
-  <rule ref="Drupal.Functions.FunctionDeclaration" />
-  <rule ref="Drupal.Scope.MethodScope"/>
-  <rule ref="Drupal.WhiteSpace.ScopeIndent"/>
+  <rule ref="Drupal.WhiteSpace.ScopeIndent" />
 
   <!-- Generic sniffs -->
   <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
-  <rule ref="Generic.Files.ByteOrderMark"/>
-  <rule ref="Generic.Files.EndFileNewline" />
-  <rule ref="Generic.Files.LineEndings"/>
   <rule ref="Generic.Formatting.SpaceAfterCast"/>
-  <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
   <rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie">
     <properties>
       <property name="checkClosures" value="true"/>
@@ -33,10 +28,7 @@
   <rule ref="Generic.NamingConventions.ConstructorName"/>
   <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
   <rule ref="Generic.PHP.DeprecatedFunctions"/>
-  <rule ref="Generic.PHP.DisallowShortOpenTag"/>
-  <rule ref="Generic.PHP.LowerCaseKeyword"/>
   <rule ref="Generic.PHP.UpperCaseConstant"/>
-  <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
 
   <!-- Internal sniffs -->
   <rule ref="Internal.NoCodeFound">
@@ -62,34 +54,6 @@
   <rule ref="PEAR.Files.IncludingFile.UseRequire">
     <severity>0</severity>
   </rule>
-  <rule ref="PEAR.Functions.FunctionCallSignature.OpeningIndent">
-    <severity>0</severity>
-  </rule>
-  <rule ref="PEAR.Functions.ValidDefaultValue"/>
-  <rule ref="PEAR.Functions.FunctionCallSignature"/>
-  <!-- The sniffs inside PEAR.Functions.FunctionCallSignature silenced below are
-    also silenced in Drupal CS' ruleset.xml. The code below is a 1-to-1 copy
-    from that file. -->
-  <!-- Disable some error messages that we already cover. -->
-  <rule ref="PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket">
-    <severity>0</severity>
-  </rule>
-  <rule ref="PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket">
-    <severity>0</severity>
-  </rule>
-  <!-- Disable some error messages that we do not want. -->
-  <rule ref="PEAR.Functions.FunctionCallSignature.Indent">
-    <severity>0</severity>
-  </rule>
-  <rule ref="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket">
-    <severity>0</severity>
-  </rule>
-  <rule ref="PEAR.Functions.FunctionCallSignature.CloseBracketLine">
-    <severity>0</severity>
-  </rule>
-  <rule ref="PEAR.Functions.FunctionCallSignature.EmptyLine">
-    <severity>0</severity>
-  </rule>
 
   <!-- PHP Compatibility sniffs -->
   <!-- The lowest version of PHP supported by both Drupal and Acquia Cloud.
@@ -101,18 +65,6 @@
   <rule ref="PHPCompatibility">
     <exclude name="PHPCompatibility.Extensions.RemovedExtensions.famRemoved"/>
   </rule>
-
-  <!-- PSR-2 sniffs -->
-  <rule ref="PSR2.Classes.PropertyDeclaration">
-    <exclude name="PSR2.Classes.PropertyDeclaration.Underscore"/>
-  </rule>
-  <rule ref="PSR2.Namespaces.NamespaceDeclaration"/>
-  <rule ref="PSR2.Namespaces.UseDeclaration">
-    <exclude name="PSR2.Namespaces.UseDeclaration.UseAfterNamespace"/>
-  </rule>
-
-  <!-- PSR-12 sniffs -->
-  <rule ref="PSR12.Functions.ReturnTypeDeclaration" />
 
   <!-- SlevomatCodingStandard sniffs -->
   <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses" />
@@ -163,52 +115,6 @@
   <rule ref="Squiz.Arrays.ArrayDeclaration.ValueNoNewline">
     <severity>0</severity>
   </rule>
-  <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration"/>
-  <!-- Disable some error messages that we already cover. -->
-  <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration.AsNotLower">
-    <severity>0</severity>
-  </rule>
-  <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration.SpaceAfterOpen">
-    <severity>0</severity>
-  </rule>
-  <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration.SpaceBeforeClose">
-    <severity>0</severity>
-  </rule>
-  <rule ref="Squiz.ControlStructures.ForLoopDeclaration"/>
-  <!-- Disable some error messages that we already cover. -->
-  <rule ref="Squiz.ControlStructures.ForLoopDeclaration.SpacingAfterOpen">
-    <severity>0</severity>
-  </rule>
-  <rule ref="Squiz.ControlStructures.ForLoopDeclaration.SpacingBeforeClose">
-    <severity>0</severity>
-  </rule>
-  <rule ref="Squiz.Functions.MultiLineFunctionDeclaration"/>
-  <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine">
-    <severity>0</severity>
-  </rule>
-  <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.ContentAfterBrace">
-    <severity>0</severity>
-  </rule>
-  <!-- Standard yet to be finalized on this
-    (https://www.drupal.org/node/1539712). -->
-  <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.FirstParamSpacing">
-    <severity>0</severity>
-  </rule>
-  <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.Indent">
-    <severity>0</severity>
-  </rule>
-  <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.CloseBracketLine">
-    <severity>0</severity>
-  </rule>
-  <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
-    <properties>
-      <property name="equalsSpacing" value="1"/>
-    </properties>
-  </rule>
-  <rule
-    ref="Squiz.Functions.FunctionDeclarationArgumentSpacing.NoSpaceBeforeArg">
-    <severity>0</severity>
-  </rule>
   <rule ref="Squiz.PHP.LowercasePHPFunctions"/>
   <rule ref="Squiz.Strings.ConcatenationSpacing">
     <properties>
@@ -225,8 +131,5 @@
   <rule ref="Squiz.WhiteSpace.OperatorSpacing" />
   <rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
   <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
-
-  <!-- Zend sniffs -->
-  <rule ref="Zend.Files.ClosingTag"/>
 
 </ruleset>

--- a/src/Standards/AcquiaPHP/ruleset.xml
+++ b/src/Standards/AcquiaPHP/ruleset.xml
@@ -67,6 +67,8 @@
   </rule>
 
   <!-- SlevomatCodingStandard sniffs -->
+  <rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing" />
+  <rule ref="SlevomatCodingStandard.Commenting.EmptyComment" />
   <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses" />
   <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint" />
   <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint" />

--- a/src/Standards/AcquiaPHP/ruleset.xml
+++ b/src/Standards/AcquiaPHP/ruleset.xml
@@ -13,8 +13,15 @@
     <exclude name="Generic.WhiteSpace.ScopeIndent"/>
     <exclude name="Generic.PHP.LowerCaseConstant"/>
     <exclude name="PSR2.Classes.ClassDeclaration"/>
+    <exclude name="PSR2.Methods.FunctionCallSignature"/>
     <exclude name="Squiz.Functions.FunctionDeclaration"/>
     <exclude name="Squiz.Functions.MultiLineFunctionDeclaration"/>
+  </rule>
+
+  <rule ref="PEAR.Functions.FunctionCallSignature">
+    <properties>
+      <property name="indent" value="2"/>
+    </properties>
   </rule>
 
   <!-- Drupal sniffs -->

--- a/src/Standards/AcquiaPHP/ruleset.xml
+++ b/src/Standards/AcquiaPHP/ruleset.xml
@@ -67,6 +67,13 @@
     <severity>0</severity>
   </rule>
 
+  <!-- PSR-12 sniffs -->
+  <rule ref="PSR12.ControlStructures.ControlStructureSpacing">
+    <properties>
+      <property name="indent" value="2"/>
+    </properties>
+  </rule>
+
   <!-- PHP Compatibility sniffs -->
   <!-- The lowest version of PHP supported by both Drupal and Acquia Cloud.
     @see https://www.drupal.org/docs/8/system-requirements/php-requirements

--- a/src/Standards/AcquiaPHP/ruleset.xml
+++ b/src/Standards/AcquiaPHP/ruleset.xml
@@ -15,6 +15,7 @@
 
   <!-- Drupal sniffs -->
   <rule ref="Drupal.Classes.UnusedUseStatement"/>
+  <rule ref="Drupal.Commenting.InlineComment"/>
   <rule ref="Drupal.WhiteSpace.ScopeIndent"/>
 
   <!-- Generic sniffs -->
@@ -67,15 +68,39 @@
   </rule>
 
   <!-- SlevomatCodingStandard sniffs -->
-  <rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing" />
-  <rule ref="SlevomatCodingStandard.Commenting.EmptyComment" />
-  <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses" />
-  <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint" />
-  <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint" />
-  <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint" />
+  <rule ref="SlevomatCodingStandard.Arrays.AlphabeticallySortedByKeys"/>
+  <rule ref="SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation"/>
+  <rule ref="SlevomatCodingStandard.Arrays.MultiLineArrayEndBracketPlacement"/>
+  <rule ref="SlevomatCodingStandard.Arrays.SingleLineArrayWhitespace"/>
+  <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
+  <rule ref="SlevomatCodingStandard.Classes.RequireConstructorPropertyPromotion"/>
+  <rule ref="SlevomatCodingStandard.Commenting.DeprecatedAnnotationDeclaration"/>
+  <rule ref="SlevomatCodingStandard.Commenting.DisallowCommentAfterCode"/>
+  <rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing"/>
+  <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
+  <rule ref="SlevomatCodingStandard.Commenting.ForbiddenAnnotations">
+    <properties>
+      <property name="forbiddenAnnotations" type="array" value="@author,@created,@version,@package,@copyright,@license,@throws"/>
+    </properties>
+  </rule>
+  <rule ref="SlevomatCodingStandard.Commenting.ForbiddenComments">
+    <properties>
+      <property name="forbiddenCommentPatterns" type="array" value="/Class .*/"/>
+    </properties>
+  </rule>
+  <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration"/>
+  <rule ref="SlevomatCodingStandard.Commenting.UselessFunctionDocComment"/>
+  <rule ref="SlevomatCodingStandard.Commenting.UselessInheritDocComment"/>
+  <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses"/>
+  <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes"/>
+  <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
+    <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification"/>
+  </rule>
+  <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint"/>
+  <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint"/>
   <!-- Superglobals are superbad. See linked issue for discussion.
   @see https://github.com/acquia/coding-standards-php/issues/49 -->
-  <rule ref="SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable" />
+  <rule ref="SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable"/>
 
   <!-- Squiz sniffs -->
   <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
@@ -130,7 +155,7 @@
     </properties>
   </rule>
   <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
-  <rule ref="Squiz.WhiteSpace.OperatorSpacing" />
+  <rule ref="Squiz.WhiteSpace.OperatorSpacing"/>
   <rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
   <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
 

--- a/src/Standards/AcquiaPHP/ruleset.xml
+++ b/src/Standards/AcquiaPHP/ruleset.xml
@@ -15,7 +15,7 @@
 
   <!-- Drupal sniffs -->
   <rule ref="Drupal.Classes.UnusedUseStatement"/>
-  <rule ref="Drupal.WhiteSpace.ScopeIndent" />
+  <rule ref="Drupal.WhiteSpace.ScopeIndent"/>
 
   <!-- Generic sniffs -->
   <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>

--- a/src/Standards/AcquiaPHP/ruleset.xml
+++ b/src/Standards/AcquiaPHP/ruleset.xml
@@ -8,11 +8,13 @@
 
   <description>Acquia's PHP coding standards.</description>
 
+  <!-- The Acquia PHP standard is PSR-12 modified to be compatible with Drupal standards -->
   <rule ref="PSR12">
     <exclude name="Generic.WhiteSpace.ScopeIndent"/>
     <exclude name="Generic.PHP.LowerCaseConstant"/>
     <exclude name="PSR2.Classes.ClassDeclaration"/>
     <exclude name="Squiz.Functions.FunctionDeclaration"/>
+    <exclude name="Squiz.Functions.MultiLineFunctionDeclaration"/>
   </rule>
 
   <!-- Drupal sniffs -->
@@ -148,6 +150,23 @@
     <severity>0</severity>
   </rule>
   <rule ref="Squiz.Arrays.ArrayDeclaration.ValueNoNewline">
+    <severity>0</severity>
+  </rule>
+  <rule ref="Squiz.Functions.MultiLineFunctionDeclaration" />
+  <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine">
+    <severity>0</severity>
+  </rule>
+  <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.ContentAfterBrace">
+    <severity>0</severity>
+  </rule>
+  <!-- Standard yet to be finalized on this (https://www.drupal.org/node/1539712). -->
+  <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.FirstParamSpacing">
+    <severity>0</severity>
+  </rule>
+  <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.Indent">
+    <severity>0</severity>
+  </rule>
+  <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.CloseBracketLine">
     <severity>0</severity>
   </rule>
   <rule ref="Squiz.PHP.LowercasePHPFunctions"/>


### PR DESCRIPTION
This is a ground-up rewrite of the Acquia PHP standard to be based on PSR-12 and compatible with Drupal standards. In other words, any code adhering to Acquia PHP will also adhere to Drupal standards, but not necessarily vice-versa.

This means that Acquia PHP is a stricter subset of PSR-12 and the Drupal standards, which is a paradigm shift from its original implementation as a _looser_ standard (and hence, base of) the Drupal standards. This warrants a new major release.

PER isn't available in PHPCS yet, but the good news is it's mostly backwards-compatible (i.e., only contains additions for new PHP features) and can we can basically swap it in for PSR-12 when it lands: 
https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/29

The best way to test this is against projects already on the latest version of the AcquiaPHP or AcquiaDrupal* standards.

- For AcquiaDrupal* projects, see that nothing changes. If anything, the standards might be a little looser now.
- For AcquiaPHP projects, see that the standard is slightly more strict and incorporates PSR-12 elements.

### Dependency changes

| Production Changes                 | From     | To       | Compare                                                                                  |
|------------------------------------|----------|----------|------------------------------------------------------------------------------------------|
| drupal/coder                       | 8.3.18   | 8.3.23   | [...](https://github.com/pfrenssen/coder/compare/8.3.18...8.3.23)                        |
| phpstan/phpdoc-parser              | 1.20.4   | 1.27.0   | [...](https://github.com/phpstan/phpdoc-parser/compare/1.20.4...1.27.0)                  |
| sirbrillig/phpcs-variable-analysis | v2.11.16 | v2.11.17 | [...](https://github.com/sirbrillig/phpcs-variable-analysis/compare/v2.11.16...v2.11.17) |
| slevomat/coding-standard           | 8.12.1   | 8.15.0   | [...](https://github.com/slevomat/coding-standard/compare/8.12.1...8.15.0)               |
| squizlabs/php_codesniffer          | 3.7.2    | 3.9.0    | [...](https://github.com/PHPCSStandards/PHP_CodeSniffer/compare/3.7.2...3.9.0)           |
| symfony/polyfill-ctype             | v1.27.0  | v1.29.0  | [...](https://github.com/symfony/polyfill-ctype/compare/v1.27.0...v1.29.0)               |
| symfony/yaml                       | v6.2.10  | v6.4.3   | [...](https://github.com/symfony/yaml/compare/v6.2.10...v6.4.3)                          |
| symfony/deprecation-contracts      | NEW      | v3.4.0   |                                                                                          |