### PR TITLE
RCAT-684 | Enable D11 jobs

### DIFF
--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -11,7 +11,7 @@ on:
         -   cron: "0 0 * * 0"
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       ORCA_SUT_NAME: acquia/coding-standards
       ORCA_SUT_BRANCH: master
@@ -61,18 +61,18 @@ jobs:
             php-version: "8.0"
             coveralls-enable: "FALSE"
             orca-version: "^3"
-          # - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
-          #   php-version: "8.1"
-          #   coveralls-enable: "FALSE"
-          # - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
-          #   php-version: "8.1"
-          #   coveralls-enable: "FALSE"
-          # - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
-          #   php-version: "8.1"
-          #   coveralls-enable: "FALSE"
-          # - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
-          #   php-version: "8.1"
-          #   coveralls-enable: "FALSE"
+
+          # Testing Drupal 11 in php 8.3.
+          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+            php-version: "8.3"
+          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+            php-version: "8.3"
+            -enable: "FALSE"
+          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
+            php-version: "8.3"
+          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
+            php-version: "8.3"
+
           # - orca-job: ISOLATED_TEST_ON_CURRENT
           #   php-version: "8.0"
           #   coveralls-enable: "FALSE"

--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -62,12 +62,10 @@ jobs:
             coveralls-enable: "FALSE"
             orca-version: "^3"
 
-          # Testing Drupal 11 in php 8.3.
           - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
             php-version: "8.3"
           - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
             php-version: "8.3"
-            -enable: "FALSE"
           - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
             php-version: "8.3"
           - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER


### PR DESCRIPTION
Motivation
Enables jobs to test D11 readiness RCAT-684

Proposed changes
Following jobs are added for D11 with php8.3 -

- ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
- INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
- ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
- INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
