### PR TITLE
Apply indentation to array contents

### DIFF
--- a/src/Standards/AcquiaPHPMinimal/ruleset.xml
+++ b/src/Standards/AcquiaPHPMinimal/ruleset.xml
@@ -27,12 +27,14 @@
     <exclude name="PHPCompatibility.Extensions.RemovedExtensions.famRemoved"/>
   </rule>
 
-  <!-- Apply indentation rules to all kinds of code (i.e., tokens), including comments. -->
+  <!-- Apply indentation rules to comments and arrays. -->
   <!-- @see https://github.com/squizlabs/PHP_CodeSniffer/issues/2314 -->
+  <!-- @see https://github.com/squizlabs/PHP_CodeSniffer/issues/1235 -->
   <rule ref="Generic.WhiteSpace.ScopeIndent">
     <properties>
       <property name="ignoreIndentationTokens" type="array"/>
     </properties>
   </rule>
+  <rule ref="Generic.Arrays.ArrayIndent"/>
 
 </ruleset>


### PR DESCRIPTION
Given the following code:

```php
<?php
$foo = [
    'bar',
];
```

Running `phpcbf` removes all indentation:

```php
<?php
$foo = [
'bar',
];
```

This really mangles multidimensional arrays.

PSR-12 doesn't explicitly mention how arrays should be indented but there is [one example](https://www.php-fig.org/psr/psr-12/#47-method-and-function-calls) that indicates contents should be indented, and I think we can all agree it's common sense.

Upstream issue: https://github.com/squizlabs/PHP_CodeSniffer/issues/1235

Example of this rule applied to ACLI: https://github.com/acquia/cli/commit/4bfe4f46e40cfb970e38dddbf12f638fbdb0795e