### PR TITLE
Drupal.Classes.UnusedUseStatement

### DIFF
--- a/src/Standards/AcquiaPHPStrict/ruleset.xml
+++ b/src/Standards/AcquiaPHPStrict/ruleset.xml
@@ -11,6 +11,7 @@
   <rule ref="AcquiaPHPMinimal"/>
 
   <!-- Drupal sniffs -->
+  <rule ref="Drupal.Classes.UnusedUseStatement"/>
   <rule ref="Drupal.Commenting.InlineComment"/>
 
   <!-- SlevomatCodingStandard sniffs -->


### PR DESCRIPTION
This was in v2 and should have been in v3, I guess we overlooked it. We definitely want to catch unused use statements.