### PR TITLE
Moves testversion over to example file.

### DIFF
--- a/example/phpcs.xml.dist
+++ b/example/phpcs.xml.dist
@@ -23,4 +23,10 @@
   <!-- @see https://github.com/squizlabs/PHP_CodeSniffer/issues/981 -->
   <exclude-pattern>vendor/*</exclude-pattern>
 
+  <!-- The lowest version of PHP supported by both Drupal and Acquia Cloud.
+    @see https://www.drupal.org/docs/8/system-requirements/php-requirements
+    @see https://docs.acquia.com/acquia-cloud/arch/tech-platform/
+    Set PHP version to match your project version -->
+  <config name="testVersion" value="7.4-"/>
+
 </ruleset>

--- a/src/Standards/AcquiaDrupalMinimal/ruleset.xml
+++ b/src/Standards/AcquiaDrupalMinimal/ruleset.xml
@@ -14,12 +14,6 @@
   </rule>
 
   <!-- PHP Compatibility sniffs -->
-  <!-- The lowest version of PHP supported by both Drupal and Acquia Cloud.
-    @see https://www.drupal.org/docs/8/system-requirements/php-requirements
-    @see https://docs.acquia.com/acquia-cloud/arch/tech-platform/
-    For instructions on overriding this value in your project,
-    @see https://github.com/acquia/coding-standards-php/pull/37 -->
-  <config name="testVersion" value="7.4-"/>
   <rule ref="PHPCompatibility">
     <exclude name="PHPCompatibility.Extensions.RemovedExtensions.famRemoved"/>
   </rule>


### PR DESCRIPTION
**Motivation**
Fixes #85

**Proposed changes**
Moves the `testVersion` setting out of the base ruleset so that it can be set at the core phpcs.xml level

