### PR TITLE
Drop ORCA 3

### DIFF
--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -30,8 +30,8 @@ jobs:
         orca-job:
           - STATIC_CODE_ANALYSIS
           - INTEGRATED_TEST_ON_OLDEST_SUPPORTED
-          - INTEGRATED_TEST_ON_LATEST_LTS
           - INTEGRATED_TEST_ON_PREVIOUS_MINOR
+          - INTEGRATED_TEST_ON_LATEST_LTS
           # - INTEGRATED_UPGRADE_TEST_FROM_PREVIOUS_MINOR
           - ISOLATED_TEST_ON_CURRENT
           - INTEGRATED_TEST_ON_CURRENT
@@ -54,21 +54,12 @@ jobs:
         include:
           - orca-job: INTEGRATED_TEST_ON_LATEST_EOL_MAJOR
             php-version: "8.1"
-            coveralls-enable: "FALSE"
-            orca-version: "^4"
-
-          - orca-job: INTEGRATED_TEST_ON_LATEST_EOL_MAJOR
-            php-version: "8.0"
-            coveralls-enable: "FALSE"
-            orca-version: "^3"
 
           - orca-job: INTEGRATED_TEST_ON_OLDEST_SUPPORTED
             php-version: "8.1"
-            orca-version: "^4"
 
           - orca-job: INTEGRATED_TEST_ON_LATEST_LTS
             php-version: "8.1"
-            orca-version: "^4"
 
           # - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
           #   php-version: "8.3"


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
I'm not sure why we were still running a test with ORCA 3, but it was causing CI to fail: https://github.com/acquia/coding-standards-php/actions/runs/17103465403/job/48506051374

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Drop the ORCA 3 test, and generally clean up the workflow to more closely match the upstream reference: https://github.com/acquia/orca/blob/develop/example/.github/workflows/orca.yml

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
