### PR TITLE
Add automated test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,32 @@
+name: Tests
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - 'support/**'
+      - wip
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.4', '8.5']
+    name: PHP ${{ matrix.php }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress
+
+      - name: Run tests
+        run: composer test

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+.phpunit.result.cache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this package is
+
+A **ruleset-composition-only** PHP_CodeSniffer package. It contains no custom PHP sniff classes — only four `ruleset.xml` files that compose rules from upstream packages (`drupal/coder`, `slevomat/coding-standard`, and PHPCS core). All sniff logic lives in those dependencies.
+
+The four standards and their intent:
+
+| Standard | Base | Audience |
+|---|---|---|
+| `AcquiaDrupalMinimal` | Drupal coding standard | Public Drupal projects |
+| `AcquiaDrupalStrict` | AcquiaDrupalMinimal + DrupalPractice | Internal Drupal projects |
+| `AcquiaPHPMinimal` | PSR-12 + Generic indentation | Public non-Drupal projects |
+| `AcquiaPHPStrict` | AcquiaPHPMinimal + Slevomat rules | Internal non-Drupal projects |
+
+## Commands
+
+```bash
+# Run all tests
+composer test
+
+# Run a single test class
+vendor/bin/phpunit tests/Standards/AcquiaPHPStrictTest.php
+
+# Run a single test method
+vendor/bin/phpunit --filter testSuperglobalUsageIsReported
+
+# Manually verify a fixture against a standard (useful when writing new tests)
+vendor/bin/phpcs -s --standard=src/Standards/AcquiaPHPStrict/ruleset.xml tests/fixtures/AcquiaPHPStrict/fail-superglobal.php
+```
+
+## Testing architecture
+
+Because this package has no custom sniffs, PHPCS's built-in `AbstractSniffUnitTest` framework does not apply. Tests drive the PHPCS PHP API directly:
+
+- `tests/bootstrap.php` — defines PHPCS constants (`PHP_CODESNIFFER_IN_TESTS`, etc.) and requires both the Composer autoloader and PHPCS's own `autoload.php` + `Util/Tokens.php`. The token constants file **must** be loaded before any sniff class is instantiated or `T_COMMA` and friends will be undefined.
+- `tests/Standards/AbstractRulesetTestCase.php` — base class with three assertion helpers: `assertStandardPasses`, `assertViolationOnLine`, `assertViolationWithCode`. Resolves standards by name from `src/Standards/<name>/ruleset.xml`.
+- `tests/Standards/<Standard>Test.php` — one test class per standard.
+- `tests/fixtures/<Standard>/` — PHP fixture files. `pass.php` is a minimal compliant file; `fail-*.php` files each trigger one specific sniff code.
+
+### Fixture path gotcha
+
+PHPCS `<exclude-pattern>tests/*</exclude-pattern>` matches on substring of the absolute file path, so any fixture stored under `tests/` will have those rules silenced. When writing a fail fixture for `AcquiaDrupalMinimal`, use a rule that is **not** in the exclusion list (e.g. `Drupal.Commenting.FileComment.Missing`). The excluded rules are: `Drupal.Arrays.Array.LongLineDeclaration`, `Drupal.Commenting.ClassComment.Missing`, `Drupal.Commenting.DocComment.MissingShort`, `Drupal.Commenting.FunctionComment.Missing`, `Drupal.Commenting.VariableComment.Missing`.
+
+## Adding or changing rules
+
+Edit the relevant `src/Standards/<Standard>/ruleset.xml`. All rule references must be to sniffs provided by the three runtime dependencies (`drupal/coder`, `slevomat/coding-standard`, `squizlabs/php_codesniffer`). When adding a rule, add a corresponding `fail-*.php` fixture and `assertViolationWithCode` test.
+
+## Branch targeting
+
+- `develop` — new work for the active `4.x` line
+- `support/3` — approved fixes for the `3.x` LTS line
+- PRs must target the correct branch; maintainers handle merges/backports

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
         "slevomat/coding-standard": "^8.4",
         "squizlabs/php_codesniffer": "^3.7"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^10 || ^11"
+    },
     "suggest": {
         "brainmaestro/composer-git-hooks": "Easily manage Git hooks in your composer config.",
         "dealerdirect/phpcodesniffer-composer-installer": "Automatically install PHP_CodeSniffer coding standards (rulesets).",
@@ -42,6 +45,14 @@
         "psr-4": {
             "Acquia\\CodingStandards\\": "src/"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Acquia\\CodingStandards\\Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "test": "phpunit"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "49108978c36224b0ab3fb7f1e7797637",
+    "content-hash": "dd7fddf4259f562e31f0ecd2596de39a",
     "packages": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -559,7 +559,1789 @@
             "time": "2026-05-25T06:08:44+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+            },
+            "time": "2025-12-06T11:56:16+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "11.0.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.2",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-text-template": "^4.0.1",
+                "sebastian/code-unit-reverse-lookup": "^4.0.1",
+                "sebastian/complexity": "^4.0.1",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/lines-of-code": "^3.0.1",
+                "sebastian/version": "^5.0.2",
+                "theseer/tokenizer": "^1.3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5.46"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.12"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-24T07:01:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-02T13:52:54+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^11.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:07:44+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:08:43+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "7.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:09:35+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "11.5.55",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/adc7262fccc12de2b30f12a8aa0b33775d814f00",
+                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.2",
+                "phpunit/php-code-coverage": "^11.0.12",
+                "phpunit/php-file-iterator": "^5.1.1",
+                "phpunit/php-invoker": "^5.0.1",
+                "phpunit/php-text-template": "^4.0.1",
+                "phpunit/php-timer": "^7.0.1",
+                "sebastian/cli-parser": "^3.0.2",
+                "sebastian/code-unit": "^3.0.3",
+                "sebastian/comparator": "^6.3.3",
+                "sebastian/diff": "^6.0.2",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/exporter": "^6.3.2",
+                "sebastian/global-state": "^7.0.2",
+                "sebastian/object-enumerator": "^6.0.1",
+                "sebastian/recursion-context": "^6.0.3",
+                "sebastian/type": "^5.1.3",
+                "sebastian/version": "^5.0.2",
+                "staabm/side-effects-detector": "^1.0.5"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.55"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-18T12:37:06+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:41:36+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-19T07:56:08+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:45:54+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "6.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/diff": "^6.0",
+                "sebastian/exporter": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.4"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:26:40+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/ee41d384ab1906c68852636b6de493846e13e5a0",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:49:50+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "6.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:53:05+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "7.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-05-21T11:55:47+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "6.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/70a298763b40b213ec087c51c739efcaa90bcd74",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:12:51+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "7.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/3be331570a721f9a4b5917f4209773de17f747d7",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:57:36+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:58:38+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "6.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f5b498e631a74204185071eb41f33f38d64608aa",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:00:13+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:01:32+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "6.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-13T04:42:22+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "5.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/5.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-09T06:55:48+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "5.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/5.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-09T05:16:32+00:00"
+        },
+        {
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {},

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+>
+  <testsuites>
+    <testsuite name="Acquia Coding Standards">
+      <directory>tests/Standards</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/tests/Standards/AbstractRulesetTestCase.php
+++ b/tests/Standards/AbstractRulesetTestCase.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acquia\CodingStandards\Tests\Standards;
+
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Files\LocalFile;
+use PHP_CodeSniffer\Ruleset;
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractRulesetTestCase extends TestCase
+{
+
+    private const STANDARDS_DIR = __DIR__ . '/../../src/Standards';
+
+    /**
+     * Asserts that the given fixture file produces zero errors and warnings.
+     */
+    protected function assertStandardPasses(string $standard, string $fixture): void
+    {
+        $file = $this->processFixture($standard, $fixture);
+        $errors = $file->getErrorCount();
+        $warnings = $file->getWarningCount();
+
+        $this->assertSame(
+            0,
+            $errors + $warnings,
+            sprintf(
+                "Expected no violations in %s under %s but found %d error(s) and %d warning(s):\n%s",
+                basename($fixture),
+                $standard,
+                $errors,
+                $warnings,
+                $this->describeViolations($file),
+            ),
+        );
+    }
+
+    /**
+     * Asserts that the given fixture file produces at least one violation on the specified line.
+     */
+    protected function assertViolationOnLine(int $line, string $standard, string $fixture): void
+    {
+        $file = $this->processFixture($standard, $fixture);
+        $allErrors = $file->getErrors();
+        $allWarnings = $file->getWarnings();
+
+        $this->assertTrue(
+            isset($allErrors[$line]) || isset($allWarnings[$line]),
+            sprintf(
+                "Expected a violation on line %d of %s under %s but found none.\nAll violations:\n%s",
+                $line,
+                basename($fixture),
+                $standard,
+                $this->describeViolations($file),
+            ),
+        );
+    }
+
+    /**
+     * Asserts that the given fixture file produces a violation with the given sniff code.
+     */
+    protected function assertViolationWithCode(string $sniffCode, string $standard, string $fixture): void
+    {
+        $file = $this->processFixture($standard, $fixture);
+        $found = false;
+
+        foreach ([$file->getErrors(), $file->getWarnings()] as $violationsByLine) {
+            foreach ($violationsByLine as $lineViolations) {
+                foreach ($lineViolations as $colViolations) {
+                    foreach ($colViolations as $violation) {
+                        if ($violation['source'] === $sniffCode) {
+                            $found = true;
+                            break 4;
+                        }
+                    }
+                }
+            }
+        }
+
+        $this->assertTrue(
+            $found,
+            sprintf(
+                "Expected violation %s in %s under %s but did not find it.\nAll violations:\n%s",
+                $sniffCode,
+                basename($fixture),
+                $standard,
+                $this->describeViolations($file),
+            ),
+        );
+    }
+
+    private function processFixture(string $standard, string $fixture): LocalFile
+    {
+        $rulesetPath = self::STANDARDS_DIR . '/' . $standard . '/ruleset.xml';
+        $config = new Config(['--standard=' . $rulesetPath]);
+        $config->cache = false;
+        $ruleset = new Ruleset($config);
+        $file = new LocalFile($fixture, $ruleset, $config);
+        $file->process();
+        return $file;
+    }
+
+    private function describeViolations(LocalFile $file): string
+    {
+        $output = '';
+        foreach ($file->getErrors() as $line => $lineErrors) {
+            foreach ($lineErrors as $colErrors) {
+                foreach ($colErrors as $error) {
+                    $output .= "  ERROR   line {$line}: {$error['message']} ({$error['source']})\n";
+                }
+            }
+        }
+        foreach ($file->getWarnings() as $line => $lineWarnings) {
+            foreach ($lineWarnings as $colWarnings) {
+                foreach ($colWarnings as $warning) {
+                    $output .= "  WARNING line {$line}: {$warning['message']} ({$warning['source']})\n";
+                }
+            }
+        }
+        return $output ?: "  (none)\n";
+    }
+
+}

--- a/tests/Standards/AbstractRulesetTestCase.php
+++ b/tests/Standards/AbstractRulesetTestCase.php
@@ -14,9 +14,6 @@ abstract class AbstractRulesetTestCase extends TestCase
 
     private const STANDARDS_DIR = __DIR__ . '/../../src/Standards';
 
-    /**
-     * Asserts that the given fixture file produces zero errors and warnings.
-     */
     protected function assertStandardPasses(string $standard, string $fixture): void
     {
         $file = $this->processFixture($standard, $fixture);
@@ -37,30 +34,6 @@ abstract class AbstractRulesetTestCase extends TestCase
         );
     }
 
-    /**
-     * Asserts that the given fixture file produces at least one violation on the specified line.
-     */
-    protected function assertViolationOnLine(int $line, string $standard, string $fixture): void
-    {
-        $file = $this->processFixture($standard, $fixture);
-        $allErrors = $file->getErrors();
-        $allWarnings = $file->getWarnings();
-
-        $this->assertTrue(
-            isset($allErrors[$line]) || isset($allWarnings[$line]),
-            sprintf(
-                "Expected a violation on line %d of %s under %s but found none.\nAll violations:\n%s",
-                $line,
-                basename($fixture),
-                $standard,
-                $this->describeViolations($file),
-            ),
-        );
-    }
-
-    /**
-     * Asserts that the given fixture file produces a violation with the given sniff code.
-     */
     protected function assertViolationWithCode(string $sniffCode, string $standard, string $fixture): void
     {
         $file = $this->processFixture($standard, $fixture);

--- a/tests/Standards/AcquiaDrupalMinimalTest.php
+++ b/tests/Standards/AcquiaDrupalMinimalTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acquia\CodingStandards\Tests\Standards;
+
+final class AcquiaDrupalMinimalTest extends AbstractRulesetTestCase
+{
+
+    private const STANDARD = 'AcquiaDrupalMinimal';
+
+    private const FIXTURES = __DIR__ . '/../fixtures/AcquiaDrupalMinimal';
+
+    public function testPassFixtureProducesNoViolations(): void
+    {
+        $this->assertStandardPasses(self::STANDARD, self::FIXTURES . '/pass.php');
+    }
+
+}

--- a/tests/Standards/AcquiaDrupalMinimalTest.php
+++ b/tests/Standards/AcquiaDrupalMinimalTest.php
@@ -16,4 +16,13 @@ final class AcquiaDrupalMinimalTest extends AbstractRulesetTestCase
         $this->assertStandardPasses(self::STANDARD, self::FIXTURES . '/pass.php');
     }
 
+    public function testMissingFileCommentIsReported(): void
+    {
+        $this->assertViolationWithCode(
+            'Drupal.Commenting.FileComment.Missing',
+            self::STANDARD,
+            self::FIXTURES . '/fail-missing-file-comment.php',
+        );
+    }
+
 }

--- a/tests/Standards/AcquiaDrupalStrictTest.php
+++ b/tests/Standards/AcquiaDrupalStrictTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acquia\CodingStandards\Tests\Standards;
+
+final class AcquiaDrupalStrictTest extends AbstractRulesetTestCase
+{
+
+    private const STANDARD = 'AcquiaDrupalStrict';
+
+    private const FIXTURES = __DIR__ . '/../fixtures/AcquiaDrupalStrict';
+
+    public function testPassFixtureProducesNoViolations(): void
+    {
+        $this->assertStandardPasses(self::STANDARD, self::FIXTURES . '/pass.php');
+    }
+
+}

--- a/tests/Standards/AcquiaDrupalStrictTest.php
+++ b/tests/Standards/AcquiaDrupalStrictTest.php
@@ -16,4 +16,14 @@ final class AcquiaDrupalStrictTest extends AbstractRulesetTestCase
         $this->assertStandardPasses(self::STANDARD, self::FIXTURES . '/pass.php');
     }
 
+    // Validates that the DrupalPractice ruleset is wired up (not just AcquiaDrupalMinimal).
+    public function testExceptionTranslationIsReported(): void
+    {
+        $this->assertViolationWithCode(
+            'DrupalPractice.General.ExceptionT.ExceptionT',
+            self::STANDARD,
+            self::FIXTURES . '/fail-exception-translation.php',
+        );
+    }
+
 }

--- a/tests/Standards/AcquiaPHPMinimalTest.php
+++ b/tests/Standards/AcquiaPHPMinimalTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acquia\CodingStandards\Tests\Standards;
+
+final class AcquiaPHPMinimalTest extends AbstractRulesetTestCase
+{
+
+    private const STANDARD = 'AcquiaPHPMinimal';
+
+    private const FIXTURES = __DIR__ . '/../fixtures/AcquiaPHPMinimal';
+
+    public function testPassFixtureProducesNoViolations(): void
+    {
+        $this->assertStandardPasses(self::STANDARD, self::FIXTURES . '/pass.php');
+    }
+
+}

--- a/tests/Standards/AcquiaPHPMinimalTest.php
+++ b/tests/Standards/AcquiaPHPMinimalTest.php
@@ -16,4 +16,15 @@ final class AcquiaPHPMinimalTest extends AbstractRulesetTestCase
         $this->assertStandardPasses(self::STANDARD, self::FIXTURES . '/pass.php');
     }
 
+    // Regression: Generic.Arrays.ArrayIndent was added in PR #71 after phpcbf
+    // was found to strip all array indentation instead of enforcing it.
+    public function testUnindentedArrayContentsAreReported(): void
+    {
+        $this->assertViolationWithCode(
+            'Generic.Arrays.ArrayIndent.KeyIncorrect',
+            self::STANDARD,
+            self::FIXTURES . '/fail-array-indent.php',
+        );
+    }
+
 }

--- a/tests/Standards/AcquiaPHPStrictTest.php
+++ b/tests/Standards/AcquiaPHPStrictTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Acquia\CodingStandards\Tests\Standards;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 final class AcquiaPHPStrictTest extends AbstractRulesetTestCase
 {
 
@@ -16,125 +18,73 @@ final class AcquiaPHPStrictTest extends AbstractRulesetTestCase
         $this->assertStandardPasses(self::STANDARD, self::FIXTURES . '/pass.php');
     }
 
-    public function testMissingDeclareStrictTypesIsReported(): void
+    public static function violationCases(): iterable
     {
-        $this->assertViolationWithCode(
-            'SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing',
-            self::STANDARD,
-            self::FIXTURES . '/fail-declare-strict-types.php',
-        );
+        return [
+            // Four cases cover the full custom DeclareStrictTypes config.
+            'declare(strict_types=1) missing entirely' => [
+                'fail-declare-strict-types.php',
+                'SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing',
+            ],
+            // spacesCountAroundEqualsSign=0 overrides Slevomat default to avoid PSR-12 conflict.
+            'declare with spaces around equals' => [
+                'fail-declare-strict-types-spaces.php',
+                'SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectStrictTypesFormat',
+            ],
+            'declare without blank line before (linesCountBeforeDeclare=1 config)' => [
+                'fail-declare-strict-types-no-line-before.php',
+                'SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectWhitespaceBeforeDeclare',
+            ],
+            'declare without blank line after (linesCountAfterDeclare=1 config)' => [
+                'fail-declare-strict-types-no-line-after.php',
+                'SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectWhitespaceAfterDeclare',
+            ],
+
+            'superglobal variable' => [
+                'fail-superglobal.php',
+                'SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable.DisallowedSuperGlobalVariable',
+            ],
+            'unsorted use statements' => [
+                'fail-unsorted-uses.php',
+                'SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses.IncorrectlyOrderedUses',
+            ],
+
+            // Regression: rule was omitted from the v3 rewrite, re-added in PR #74.
+            'unused use statement' => [
+                'fail-unused-use.php',
+                'Drupal.Classes.UnusedUseStatement.UnusedUse',
+            ],
+
+            // Regression: deprecated comma-separated array property syntax silently
+            // broke both rules until fixed in PR #84.
+            'forbidden @author annotation' => [
+                'fail-forbidden-annotation.php',
+                'SlevomatCodingStandard.Commenting.ForbiddenAnnotations.AnnotationForbidden',
+            ],
+            '"Class X." forbidden comment pattern' => [
+                'fail-forbidden-comment.php',
+                'SlevomatCodingStandard.Commenting.ForbiddenComments.CommentForbidden',
+            ],
+
+            'property without type hint' => [
+                'fail-missing-type-hints.php',
+                'SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint',
+            ],
+            'parameter without type hint' => [
+                'fail-missing-type-hints.php',
+                'SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint',
+            ],
+            'return without type hint' => [
+                'fail-missing-type-hints.php',
+                'SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint',
+            ],
+        ];
     }
 
-    // Validates the custom spacesCountAroundEqualsSign=0 configuration, which
-    // overrides Slevomat's default to avoid conflict with PSR-12 spacing rules.
-    public function testDeclareStrictTypesWithSpacesIsReported(): void
+    #[DataProvider('violationCases')]
+    public function testViolationIsReported(string $fixture, string $sniffCode): void
     {
-        $this->assertViolationWithCode(
-            'SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectStrictTypesFormat',
-            self::STANDARD,
-            self::FIXTURES . '/fail-declare-strict-types-spaces.php',
-        );
-    }
-
-    public function testSuperglobalUsageIsReported(): void
-    {
-        $this->assertViolationWithCode(
-            'SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable.DisallowedSuperGlobalVariable',
-            self::STANDARD,
-            self::FIXTURES . '/fail-superglobal.php',
-        );
-    }
-
-    public function testUnsortedUseStatementsAreReported(): void
-    {
-        $this->assertViolationWithCode(
-            'SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses.IncorrectlyOrderedUses',
-            self::STANDARD,
-            self::FIXTURES . '/fail-unsorted-uses.php',
-        );
-    }
-
-    // Regression: UnusedUseStatement was omitted from the v3 ruleset and
-    // re-added in PR #74 after being discovered missing.
-    public function testUnusedUseStatementIsReported(): void
-    {
-        $this->assertViolationWithCode(
-            'Drupal.Classes.UnusedUseStatement.UnusedUse',
-            self::STANDARD,
-            self::FIXTURES . '/fail-unused-use.php',
-        );
-    }
-
-    // Regression: ForbiddenAnnotations used deprecated comma-separated array
-    // syntax (issue #83 / PR #84), which silently broke the rule. This test
-    // validates the <element> syntax fix actually fires the rule.
-    public function testForbiddenAnnotationIsReported(): void
-    {
-        $this->assertViolationWithCode(
-            'SlevomatCodingStandard.Commenting.ForbiddenAnnotations.AnnotationForbidden',
-            self::STANDARD,
-            self::FIXTURES . '/fail-forbidden-annotation.php',
-        );
-    }
-
-    // Regression: ForbiddenComments had the same deprecated array syntax issue
-    // as ForbiddenAnnotations (issue #83 / PR #84).
-    public function testForbiddenCommentPatternIsReported(): void
-    {
-        $this->assertViolationWithCode(
-            'SlevomatCodingStandard.Commenting.ForbiddenComments.CommentForbidden',
-            self::STANDARD,
-            self::FIXTURES . '/fail-forbidden-comment.php',
-        );
-    }
-
-    // Validates the custom linesCountBeforeDeclare=1 property. If this config
-    // were removed, declare directly after <?php would be silently accepted.
-    public function testDeclareStrictTypesWithNoLineBeforeIsReported(): void
-    {
-        $this->assertViolationWithCode(
-            'SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectWhitespaceBeforeDeclare',
-            self::STANDARD,
-            self::FIXTURES . '/fail-declare-strict-types-no-line-before.php',
-        );
-    }
-
-    // Validates the custom linesCountAfterDeclare=1 property. If this config
-    // were removed, namespace immediately after declare would be silently accepted.
-    public function testDeclareStrictTypesWithNoLineAfterIsReported(): void
-    {
-        $this->assertViolationWithCode(
-            'SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectWhitespaceAfterDeclare',
-            self::STANDARD,
-            self::FIXTURES . '/fail-declare-strict-types-no-line-after.php',
-        );
-    }
-
-    public function testMissingPropertyTypeHintIsReported(): void
-    {
-        $this->assertViolationWithCode(
-            'SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint',
-            self::STANDARD,
-            self::FIXTURES . '/fail-missing-type-hints.php',
-        );
-    }
-
-    public function testMissingParameterTypeHintIsReported(): void
-    {
-        $this->assertViolationWithCode(
-            'SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint',
-            self::STANDARD,
-            self::FIXTURES . '/fail-missing-type-hints.php',
-        );
-    }
-
-    public function testMissingReturnTypeHintIsReported(): void
-    {
-        $this->assertViolationWithCode(
-            'SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint',
-            self::STANDARD,
-            self::FIXTURES . '/fail-missing-type-hints.php',
-        );
+        $this->assertViolationWithCode($sniffCode, self::STANDARD, self::FIXTURES . '/' . $fixture);
     }
 
 }

--- a/tests/Standards/AcquiaPHPStrictTest.php
+++ b/tests/Standards/AcquiaPHPStrictTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acquia\CodingStandards\Tests\Standards;
+
+final class AcquiaPHPStrictTest extends AbstractRulesetTestCase
+{
+
+    private const STANDARD = 'AcquiaPHPStrict';
+
+    private const FIXTURES = __DIR__ . '/../fixtures/AcquiaPHPStrict';
+
+    public function testPassFixtureProducesNoViolations(): void
+    {
+        $this->assertStandardPasses(self::STANDARD, self::FIXTURES . '/pass.php');
+    }
+
+}

--- a/tests/Standards/AcquiaPHPStrictTest.php
+++ b/tests/Standards/AcquiaPHPStrictTest.php
@@ -16,4 +16,31 @@ final class AcquiaPHPStrictTest extends AbstractRulesetTestCase
         $this->assertStandardPasses(self::STANDARD, self::FIXTURES . '/pass.php');
     }
 
+    public function testMissingDeclareStrictTypesIsReported(): void
+    {
+        $this->assertViolationWithCode(
+            'SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing',
+            self::STANDARD,
+            self::FIXTURES . '/fail-declare-strict-types.php',
+        );
+    }
+
+    public function testSuperglobalUsageIsReported(): void
+    {
+        $this->assertViolationWithCode(
+            'SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable.DisallowedSuperGlobalVariable',
+            self::STANDARD,
+            self::FIXTURES . '/fail-superglobal.php',
+        );
+    }
+
+    public function testUnsortedUseStatementsAreReported(): void
+    {
+        $this->assertViolationWithCode(
+            'SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses.IncorrectlyOrderedUses',
+            self::STANDARD,
+            self::FIXTURES . '/fail-unsorted-uses.php',
+        );
+    }
+
 }

--- a/tests/Standards/AcquiaPHPStrictTest.php
+++ b/tests/Standards/AcquiaPHPStrictTest.php
@@ -25,6 +25,17 @@ final class AcquiaPHPStrictTest extends AbstractRulesetTestCase
         );
     }
 
+    // Validates the custom spacesCountAroundEqualsSign=0 configuration, which
+    // overrides Slevomat's default to avoid conflict with PSR-12 spacing rules.
+    public function testDeclareStrictTypesWithSpacesIsReported(): void
+    {
+        $this->assertViolationWithCode(
+            'SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectStrictTypesFormat',
+            self::STANDARD,
+            self::FIXTURES . '/fail-declare-strict-types-spaces.php',
+        );
+    }
+
     public function testSuperglobalUsageIsReported(): void
     {
         $this->assertViolationWithCode(
@@ -40,6 +51,40 @@ final class AcquiaPHPStrictTest extends AbstractRulesetTestCase
             'SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses.IncorrectlyOrderedUses',
             self::STANDARD,
             self::FIXTURES . '/fail-unsorted-uses.php',
+        );
+    }
+
+    // Regression: UnusedUseStatement was omitted from the v3 ruleset and
+    // re-added in PR #74 after being discovered missing.
+    public function testUnusedUseStatementIsReported(): void
+    {
+        $this->assertViolationWithCode(
+            'Drupal.Classes.UnusedUseStatement.UnusedUse',
+            self::STANDARD,
+            self::FIXTURES . '/fail-unused-use.php',
+        );
+    }
+
+    // Regression: ForbiddenAnnotations used deprecated comma-separated array
+    // syntax (issue #83 / PR #84), which silently broke the rule. This test
+    // validates the <element> syntax fix actually fires the rule.
+    public function testForbiddenAnnotationIsReported(): void
+    {
+        $this->assertViolationWithCode(
+            'SlevomatCodingStandard.Commenting.ForbiddenAnnotations.AnnotationForbidden',
+            self::STANDARD,
+            self::FIXTURES . '/fail-forbidden-annotation.php',
+        );
+    }
+
+    // Regression: ForbiddenComments had the same deprecated array syntax issue
+    // as ForbiddenAnnotations (issue #83 / PR #84).
+    public function testForbiddenCommentPatternIsReported(): void
+    {
+        $this->assertViolationWithCode(
+            'SlevomatCodingStandard.Commenting.ForbiddenComments.CommentForbidden',
+            self::STANDARD,
+            self::FIXTURES . '/fail-forbidden-comment.php',
         );
     }
 

--- a/tests/Standards/AcquiaPHPStrictTest.php
+++ b/tests/Standards/AcquiaPHPStrictTest.php
@@ -88,4 +88,53 @@ final class AcquiaPHPStrictTest extends AbstractRulesetTestCase
         );
     }
 
+    // Validates the custom linesCountBeforeDeclare=1 property. If this config
+    // were removed, declare directly after <?php would be silently accepted.
+    public function testDeclareStrictTypesWithNoLineBeforeIsReported(): void
+    {
+        $this->assertViolationWithCode(
+            'SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectWhitespaceBeforeDeclare',
+            self::STANDARD,
+            self::FIXTURES . '/fail-declare-strict-types-no-line-before.php',
+        );
+    }
+
+    // Validates the custom linesCountAfterDeclare=1 property. If this config
+    // were removed, namespace immediately after declare would be silently accepted.
+    public function testDeclareStrictTypesWithNoLineAfterIsReported(): void
+    {
+        $this->assertViolationWithCode(
+            'SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectWhitespaceAfterDeclare',
+            self::STANDARD,
+            self::FIXTURES . '/fail-declare-strict-types-no-line-after.php',
+        );
+    }
+
+    public function testMissingPropertyTypeHintIsReported(): void
+    {
+        $this->assertViolationWithCode(
+            'SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint',
+            self::STANDARD,
+            self::FIXTURES . '/fail-missing-type-hints.php',
+        );
+    }
+
+    public function testMissingParameterTypeHintIsReported(): void
+    {
+        $this->assertViolationWithCode(
+            'SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint',
+            self::STANDARD,
+            self::FIXTURES . '/fail-missing-type-hints.php',
+        );
+    }
+
+    public function testMissingReturnTypeHintIsReported(): void
+    {
+        $this->assertViolationWithCode(
+            'SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint',
+            self::STANDARD,
+            self::FIXTURES . '/fail-missing-type-hints.php',
+        );
+    }
+
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,3 +8,6 @@ define('PHP_CODESNIFFER_IN_TESTS', true);
 define('PHP_CODESNIFFER_VERBOSITY', 0);
 
 require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../vendor/squizlabs/php_codesniffer/autoload.php';
+// Register PHPCS token constants (T_COMMA, T_WHITESPACE, etc.) used by sniffs.
+require_once __DIR__ . '/../vendor/squizlabs/php_codesniffer/src/Util/Tokens.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+// Required by PHPCS internals before any PHPCS class is loaded.
+define('PHP_CODESNIFFER_CBF', false);
+define('PHP_CODESNIFFER_IN_TESTS', true);
+define('PHP_CODESNIFFER_VERBOSITY', 0);
+
+require_once __DIR__ . '/../vendor/autoload.php';

--- a/tests/fixtures/AcquiaDrupalMinimal/fail-missing-file-comment.php
+++ b/tests/fixtures/AcquiaDrupalMinimal/fail-missing-file-comment.php
@@ -1,0 +1,3 @@
+<?php
+
+declare(strict_types=1);

--- a/tests/fixtures/AcquiaDrupalMinimal/pass.php
+++ b/tests/fixtures/AcquiaDrupalMinimal/pass.php
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * @file
+ * Example file for testing the AcquiaDrupalMinimal standard.
+ */
+
+declare(strict_types=1);

--- a/tests/fixtures/AcquiaDrupalStrict/fail-exception-translation.php
+++ b/tests/fixtures/AcquiaDrupalStrict/fail-exception-translation.php
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * @file
+ * Example file.
+ */
+
+throw new \Exception(t('Some error.'));

--- a/tests/fixtures/AcquiaDrupalStrict/pass.php
+++ b/tests/fixtures/AcquiaDrupalStrict/pass.php
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * @file
+ * Example file for testing the AcquiaDrupalStrict standard.
+ */
+
+declare(strict_types=1);

--- a/tests/fixtures/AcquiaPHPMinimal/fail-array-indent.php
+++ b/tests/fixtures/AcquiaPHPMinimal/fail-array-indent.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+$array = [
+'first',
+'second',
+];

--- a/tests/fixtures/AcquiaPHPMinimal/pass.php
+++ b/tests/fixtures/AcquiaPHPMinimal/pass.php
@@ -1,0 +1,3 @@
+<?php
+
+declare(strict_types=1);

--- a/tests/fixtures/AcquiaPHPStrict/fail-declare-strict-types-no-line-after.php
+++ b/tests/fixtures/AcquiaPHPStrict/fail-declare-strict-types-no-line-after.php
@@ -1,0 +1,4 @@
+<?php
+
+declare(strict_types=1);
+namespace Acquia\Example;

--- a/tests/fixtures/AcquiaPHPStrict/fail-declare-strict-types-no-line-before.php
+++ b/tests/fixtures/AcquiaPHPStrict/fail-declare-strict-types-no-line-before.php
@@ -1,0 +1,4 @@
+<?php
+declare(strict_types=1);
+
+namespace Acquia\Example;

--- a/tests/fixtures/AcquiaPHPStrict/fail-declare-strict-types-spaces.php
+++ b/tests/fixtures/AcquiaPHPStrict/fail-declare-strict-types-spaces.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Acquia\Example;

--- a/tests/fixtures/AcquiaPHPStrict/fail-declare-strict-types.php
+++ b/tests/fixtures/AcquiaPHPStrict/fail-declare-strict-types.php
@@ -1,0 +1,3 @@
+<?php
+
+namespace Acquia\Example;

--- a/tests/fixtures/AcquiaPHPStrict/fail-forbidden-annotation.php
+++ b/tests/fixtures/AcquiaPHPStrict/fail-forbidden-annotation.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acquia\Example;
+
+/**
+ * An example class.
+ *
+ * @author John Doe
+ */
+class Example
+{
+}

--- a/tests/fixtures/AcquiaPHPStrict/fail-forbidden-comment.php
+++ b/tests/fixtures/AcquiaPHPStrict/fail-forbidden-comment.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acquia\Example;
+
+/**
+ * Class Example.
+ */
+class Example
+{
+}

--- a/tests/fixtures/AcquiaPHPStrict/fail-missing-type-hints.php
+++ b/tests/fixtures/AcquiaPHPStrict/fail-missing-type-hints.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acquia\Example;
+
+class Example
+{
+    public $value;
+
+    public function doThing($param)
+    {
+    }
+}

--- a/tests/fixtures/AcquiaPHPStrict/fail-superglobal.php
+++ b/tests/fixtures/AcquiaPHPStrict/fail-superglobal.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acquia\Example;
+
+$value = $_GET['param'];

--- a/tests/fixtures/AcquiaPHPStrict/fail-unsorted-uses.php
+++ b/tests/fixtures/AcquiaPHPStrict/fail-unsorted-uses.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acquia\Example;
+
+use Acquia\Second\ClassB;
+use Acquia\First\ClassA;

--- a/tests/fixtures/AcquiaPHPStrict/fail-unused-use.php
+++ b/tests/fixtures/AcquiaPHPStrict/fail-unused-use.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acquia\Example;
+
+use Acquia\SomeClass;

--- a/tests/fixtures/AcquiaPHPStrict/pass.php
+++ b/tests/fixtures/AcquiaPHPStrict/pass.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acquia\Example;


### PR DESCRIPTION
Closes #72.

## Approach

Uses PHPUnit driving PHPCS's PHP API directly — `Config → Ruleset → LocalFile → process()` — rather than PHPCS's built-in `AbstractSniffUnitTest` framework, which only applies to packages that ship custom sniff classes. Since this package is ruleset-composition-only, we test the rulesets themselves.

A shared `AbstractRulesetTestCase` base class provides three assertion helpers:

- `assertStandardPasses($standard, $fixture)` — expects zero errors and warnings
- `assertViolationWithCode($sniffCode, $standard, $fixture)` — expects a specific sniff code to appear
- `processFixture()` — private; wires up Config/Ruleset/LocalFile and calls `process()`

## What's covered

Each of the four standards has a `pass.php` fixture (a minimal compliant file) and one or more `fail-*.php` fixtures that each trigger a single sniff code.

Regression tests are included for every rule that was previously missing or broken, sourced from the issue and PR history:

| Rule | Source |
|---|---|
| `Drupal.Classes.UnusedUseStatement` | Omitted in v3 rewrite — PR #74 |
| `Generic.Arrays.ArrayIndent` | phpcbf was stripping indentation — PR #71 |
| `SlevomatCodingStandard.Commenting.ForbiddenAnnotations` | Deprecated array syntax silently broke the rule — PR #84 |
| `SlevomatCodingStandard.Commenting.ForbiddenComments` | Same as above — PR #84 |
| `DrupalPractice.General.ExceptionT` | Validates DrupalPractice is wired up in AcquiaDrupalStrict |
| `DeclareStrictTypes` (spaces, line before, line after) | Validates all three custom property overrides |
| `ParameterTypeHint`, `ReturnTypeHint`, `PropertyTypeHint` | Explicitly-listed Slevomat rules with no prior coverage |

## Running locally

```bash
composer test
```

## CI

Adds a `Tests` workflow (`.github/workflows/tests.yml`) that runs on push and pull_request against PHP 8.4 and 8.5, replacing the previously disabled ORCA setup.